### PR TITLE
fix: time to first response being none caused sort failure

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -187,7 +187,9 @@ def write_to_markdown(
             file.write("no issues found for the given search criteria\n\n")
     else:
         # Sort the issues by time to first response
-        issues_with_metrics.sort(key=lambda x: x.time_to_first_response)
+        issues_with_metrics.sort(
+            key=lambda x: x.time_to_first_response or timedelta.max
+        )
         with file or open("issue_metrics.md", "w", encoding="utf-8") as file:
             file.write("# Issue Metrics\n\n")
             file.write("| Metric | Value |\n")


### PR DESCRIPTION
This pull request fixes a bug where time to first response being none (meaning there are no comments on an issue or pr) fails in the sort function. This change allows the sort to occur and takes issues/prs where time to first response is None and sorts them to the end of the list.