### PR TITLE
feat: add time in labels

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,6 @@
 GH_TOKEN = " "
 SEARCH_QUERY = "repo:owner/repo is:open is:issue"
+LABELS_TO_MEASURE = "waiting-for-review,waiting-for-manager"
 HIDE_TIME_TO_FIRST_RESPONSE = False
 HIDE_TIME_TO_CLOSE = False
 HIDE_TIME_TO_ANSWER = False

--- a/.env-example
+++ b/.env-example
@@ -3,3 +3,4 @@ SEARCH_QUERY = "repo:owner/repo is:open is:issue"
 HIDE_TIME_TO_FIRST_RESPONSE = False
 HIDE_TIME_TO_CLOSE = False
 HIDE_TIME_TO_ANSWER = False
+HIDE_LABEL_METRICS = False

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,3 +5,4 @@ disable=
 	too-few-public-methods,
 	duplicate-code,
 	too-many-locals,
+	too-many-branches,

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,4 @@ disable=
 	too-many-arguments,
 	too-few-public-methods,
 	duplicate-code,
+	too-many-locals,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The metrics that are measured are:
 |--------|-------------|
 | Time to first response | The time between when an issue/pull request/discussion is created and when the first comment or review is made. |
 | Time to close | The time between when an issue/pull request/discussion is created and when it is closed. |
-| Time to answer | The time between when a discussion is created and when it is answered. |
+| Time to answer | (Discussions only) The time between when a discussion is created and when it is answered. |
 | Time in label | The time between when a label has a specific label appplied to an issue/pull request/discussion and when it is removed. This requires the LABELS_TO_MEASURE env variable to be set. |
 
 This action was developed by the GitHub OSPO for our own use and developed in a way that we could open source it that it might be useful to you as well! If you want to know more about how we use it, reach out in an issue in this repository.

--- a/README.md
+++ b/README.md
@@ -251,13 +251,13 @@ then the report will look like this:
 | Average time to first response | 0:50:44.666667 |
 | Average time to close | 6 days, 7:08:52 |
 | Average time to answer | 1 day |
-| Average time in waiting-for-manager-approval | 0:00:41 |
-| Average time in waiting-for-security-review | 2 days, 4:25:03 |
+| Average time spent in waiting-for-manager-approval | 0:00:41 |
+| Average time spent in waiting-for-security-review | 2 days, 4:25:03 |
 | Number of items that remain open | 2 |
 | Number of items closed | 1 |
 | Total number of items created | 3 |
 
-| Title | URL | Time to first response | Time to close | Time to answer | Time in waiting-for-manager-approval | Time in waiting-for-security-review |
+| Title | URL | Time to first response | Time to close | Time to answer | Time spent in waiting-for-manager-approval | Time spent in waiting-for-security-review |
 | --- | --- | --- | --- | --- | --- | --- |
 | Pull Request Title 1 | https://github.com/user/repo/pulls/1 | 0:05:26 | None | None | None | None |
 | Issue Title 2 | https://github.com/user/repo/issues/2 | 2:26:07 | None | None | 0:00:41 | 2 days, 4:25:03 |

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ jobs:
       uses: github/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        LABELS_TO_MEASURE: 'waiting-for-manager-approval, waiting-for-security-review'
+        LABELS_TO_MEASURE: 'waiting-for-manager-approval,waiting-for-security-review'
         SEARCH_QUERY: 'repo:owner/repo is:issue created:2023-05-01..2023-05-31 -reason:"not planned"'
 
     - name: Create issue

--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 [![CodeQL](https://github.com/github/issue-metrics/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/github/issue-metrics/actions/workflows/codeql-analysis.yml) [![Docker Image CI](https://github.com/github/issue-metrics/actions/workflows/docker-image.yml/badge.svg)](https://github.com/github/issue-metrics/actions/workflows/docker-image.yml) [![Python package](https://github.com/github/issue-metrics/actions/workflows/python-package.yml/badge.svg)](https://github.com/github/issue-metrics/actions/workflows/python-package.yml)
 
-This is a GitHub Action that searches for pull requests/issues/discussions in a repository and measures
-the time to first response for each one. It then calculates the average time
-to first response and writes the issues/pull requests/discussions with their metrics
-to a Markdown file. The issues/pull requests/discussions to search for can be filtered by using a search query.
+This is a GitHub Action that searches for pull requests/issues/discussions in a repository and measures and reports on
+several metrics. The issues/pull requests/discussions to search for can be filtered by using a search query.
+
+The metrics that are measured are:
+| Metric | Description |
+|--------|-------------|
+| Time to first response | The time between when an issue/pull request/discussion is created and when the first comment or review is made. |
+| Time to close | The time between when an issue/pull request/discussion is created and when it is closed. |
+| Time to answer | The time between when a discussion is created and when it is answered. |
+| Time in label | The time between when a label has a specific label appplied to an issue/pull request/discussion and when it is removed. This requires the LABELS_TO_MEASURE env variable to be set. |
 
 This action was developed by the GitHub OSPO for our own use and developed in a way that we could open source it that it might be useful to you as well! If you want to know more about how we use it, reach out in an issue in this repository.
 
@@ -37,9 +43,11 @@ Below are the allowed configuration options:
 |-----------------------|----------|---------|-------------|
 | `GH_TOKEN`            | True     |         | The GitHub Token used to scan the repository. Must have read access to all repository you are interested in scanning. |
 | `SEARCH_QUERY`        | True     |         | The query by which you can filter issues/prs which must contain a `repo:` entry or an `org:` entry. For discussions, include `type:discussions` in the query. |
+| `LABELS_TO_MEASURE`   | False    |         | A comma separated list of labels to measure how much time the label is applied. If not provided, no labels durations will be measured. Not compatible with discussions at this time. |
 | `HIDE_TIME_TO_FIRST_RESPONSE` | False | False | If set to true, the time to first response will not be displayed in the generated markdown file. |
 | `HIDE_TIME_TO_CLOSE` | False | False | If set to true, the time to close will not be displayed in the generated markdown file. |
 | `HIDE_TIME_TO_ANSWER` | False | False | If set to true, the time to answer a discussion will not be displayed in the generated markdown file. |
+| `HIDE_LABEL_METRICS` | False | False | If set to true, the time in label metrics will not be displayed in the generated markdown file. |
 
 ### Example workflows
 
@@ -195,6 +203,65 @@ jobs:
         title: Monthly issue metrics report for closed issues and prs
         content-filepath: ./issue_metrics.md
         assignees: <YOUR_GITHUB_HANDLE_HERE>
+```
+
+## Measuring time spent in labels
+
+**Note**: The discussions API currently doesn't support the `LabeledEvent` so this action cannot measure the time spent in a label for discussions.
+
+Sometimes it is helpful to know how long an issue or pull request spent in a particular label. This action can be configured to measure the time spent in a label. This is different from only wanting to measure issues with a specific label. If that is what you want, see the section on [configuring your search query](https://github.com/github/issue-metrics/blob/main/README.md#search_query-issues-or-pull-requests-open-or-closed).
+
+Here is an example workflow that does this:
+
+```yaml
+name: Monthly issue metrics
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: issue metrics
+    runs-on: ubuntu-latest
+    
+    steps:
+
+    - name: Run issue-metrics tool
+      uses: github/issue-metrics@v2
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        LABELS_TO_MEASURE: 'waiting-for-manager-approval, waiting-for-security-review'
+        SEARCH_QUERY: 'repo:owner/repo is:issue created:2023-05-01..2023-05-31 -reason:"not planned"'
+
+    - name: Create issue
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: Monthly issue metrics report
+        content-filepath: ./issue_metrics.md
+        assignees: <YOUR_GITHUB_HANDLE_HERE>
+
+```
+
+then the report will look like this:
+
+```markdown
+# Issue Metrics
+
+| Metric | Value |
+| --- | ---: |
+| Average time to first response | 0:50:44.666667 |
+| Average time to close | 6 days, 7:08:52 |
+| Average time to answer | 1 day |
+| Average time in waiting-for-manager-approval | 0:00:41 |
+| Average time in waiting-for-security-review | 2 days, 4:25:03 |
+| Number of items that remain open | 2 |
+| Number of items closed | 1 |
+| Total number of items created | 3 |
+
+| Title | URL | Time to first response | Time to close | Time to answer | Time in waiting-for-manager-approval | Time in waiting-for-security-review |
+| --- | --- | --- | --- | --- | --- | --- |
+| Pull Request Title 1 | https://github.com/user/repo/pulls/1 | 0:05:26 | None | None | None | None |
+| Issue Title 2 | https://github.com/user/repo/issues/2 | 2:26:07 | None | None | 0:00:41 | 2 days, 4:25:03 |
+
 ```
 
 ## Example issue_metrics.md output

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Here is the output with all hidable columns hidden:
 | --- | --- |
 | Discussion Title 1 | https://github.com/user/repo/discussions/1 |
 | Pull Request Title 2 | https://github.com/user/repo/pulls/2 |
-| Issue Title 3 | https://github.com/user/repo/issues/3 | 2:26:07 |
+| Issue Title 3 | https://github.com/user/repo/issues/3 |
 
 ```
 

--- a/classes.py
+++ b/classes.py
@@ -17,6 +17,7 @@ class IssueWithMetrics:
         time_to_close (timedelta, optional): The time it took to close the issue.
         time_to_answer (timedelta, optional): The time it took to answer the
             discussions in the issue.
+        label_metrics (dict, optional): A dictionary containing the label metrics
 
     """
 
@@ -27,9 +28,11 @@ class IssueWithMetrics:
         time_to_first_response=None,
         time_to_close=None,
         time_to_answer=None,
+        labels_metrics=None,
     ):
         self.title = title
         self.html_url = html_url
         self.time_to_first_response = time_to_first_response
         self.time_to_close = time_to_close
         self.time_to_answer = time_to_answer
+        self.label_metrics = labels_metrics

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -106,7 +106,7 @@ def get_per_issue_metrics(
     labels: Union[List[str], None] = None,
 ) -> tuple[List, int, int]:
     """
-    Calculate the metrics for each issue/pr in a list provided.
+    Calculate the metrics for each issue/pr/discussion in a list provided.
 
     Args:
         issues (Union[List[dict], List[github3.issues.Issue]]): A list of

--- a/json_writer.py
+++ b/json_writer.py
@@ -27,6 +27,7 @@ def write_to_json(
     average_time_to_first_response: Union[timedelta, None],
     average_time_to_close: Union[timedelta, None],
     average_time_to_answer: Union[timedelta, None],
+    average_time_in_labels: Union[dict, None],
     num_issues_opened: Union[int, None],
     num_issues_closed: Union[int, None],
 ) -> str:
@@ -48,6 +49,9 @@ def write_to_json(
                 "time_to_first_response": "3 days, 0:00:00",
                 "time_to_close": "6 days, 0:00:00",
                 "time_to_answer": "None",
+                "label_metrics": {
+                    "bug": "1 day, 16:24:12"
+                }
             },
             {
                 "title": "Issue 2",
@@ -55,6 +59,8 @@ def write_to_json(
                 "time_to_first_response": "2 days, 0:00:00",
                 "time_to_close": "4 days, 0:00:00",
                 "time_to_answer": "1 day, 0:00:00",
+                "label_metrics": {
+                }
             },
         ],
     }
@@ -66,10 +72,15 @@ def write_to_json(
         return ""
 
     # Create a dictionary with the metrics
+    labels_metrics = {}
+    if average_time_in_labels:
+        for label, time in average_time_in_labels.items():
+            labels_metrics[label] = str(time)
     metrics = {
         "average_time_to_first_response": str(average_time_to_first_response),
         "average_time_to_close": str(average_time_to_close),
         "average_time_to_answer": str(average_time_to_answer),
+        "average_time_in_labels": labels_metrics,
         "num_items_opened": num_issues_opened,
         "num_items_closed": num_issues_closed,
         "total_item_count": len(issues_with_metrics),
@@ -78,6 +89,10 @@ def write_to_json(
     # Create a list of dictionaries with the issues and metrics
     issues = []
     for issue in issues_with_metrics:
+        formatted_label_metrics = {}
+        if issue.label_metrics:
+            for label, time in issue.label_metrics.items():
+                formatted_label_metrics[label] = str(time)
         issues.append(
             {
                 "title": issue.title,
@@ -85,6 +100,7 @@ def write_to_json(
                 "time_to_first_response": str(issue.time_to_first_response),
                 "time_to_close": str(issue.time_to_close),
                 "time_to_answer": str(issue.time_to_answer),
+                "label_metrics": formatted_label_metrics,
             }
         )
 

--- a/labels.py
+++ b/labels.py
@@ -5,6 +5,8 @@ from typing import List
 import github3
 import pytz
 
+from classes import IssueWithMetrics
+
 
 def get_label_events(
     issue: github3.issues.Issue, labels: List[str]  # type: ignore
@@ -36,31 +38,42 @@ def get_label_metrics(issue: github3.issues.Issue, labels: List[str]) -> dict:  
         labels (List[str]): A list of labels to measure time spent in.
 
     Returns:
-        dict: A dictionary containing the time spent in each label.
+        dict: A dictionary containing the time spent in each label or None.
     """
     label_metrics = {}
     label_events = get_label_events(issue, labels)
 
     for label in labels:
-        label_metrics[label] = timedelta(0)
+        label_metrics[label] = None
 
     # If the event is one of the labels we're looking for, add the time to the dictionary
     unlabeled = {}
+    labeled = {}
+    if not label_events:
+        return label_metrics
+
+    # Calculate the time to add or subtract to the time spent in label based on the label events
     for event in label_events:
         if event.event == "labeled":
+            labeled[event.label["name"]] = True
             if event.label["name"] in labels:
+                if label_metrics[event.label["name"]] is None:
+                    label_metrics[event.label["name"]] = timedelta(0)
                 label_metrics[
                     event.label["name"]
                 ] -= event.created_at - datetime.fromisoformat(issue.created_at)
         elif event.event == "unlabeled":
             unlabeled[event.label["name"]] = True
             if event.label["name"] in labels:
+                if label_metrics[event.label["name"]] is None:
+                    label_metrics[event.label["name"]] = timedelta(0)
                 label_metrics[
                     event.label["name"]
                 ] += event.created_at - datetime.fromisoformat(issue.created_at)
 
     for label in labels:
-        if label not in unlabeled:
+        # if the label is still on there, add the time from the last event to now
+        if label in labeled and label not in unlabeled:
             # if the issue is closed, add the time from the issue creation to the closed_at time
             if issue.state == "closed":
                 label_metrics[label] += datetime.fromisoformat(
@@ -73,3 +86,34 @@ def get_label_metrics(issue: github3.issues.Issue, labels: List[str]) -> dict:  
                 )
 
     return label_metrics
+
+
+def get_average_time_in_labels(
+    issues_with_metrics: List[IssueWithMetrics],
+    labels: List[str],
+) -> dict[str, timedelta]:
+    """Calculate the average time spent in each label."""
+    average_time_in_labels = {}
+    number_of_issues_in_labels = {}
+    for issue in issues_with_metrics:
+        if issue.label_metrics:
+            for label in issue.label_metrics:
+                if issue.label_metrics[label] is None:
+                    continue
+                if label not in average_time_in_labels:
+                    average_time_in_labels[label] = issue.label_metrics[label]
+                    number_of_issues_in_labels[label] = 1
+                else:
+                    average_time_in_labels[label] += issue.label_metrics[label]
+                    number_of_issues_in_labels[label] += 1
+
+    for label in average_time_in_labels:
+        average_time_in_labels[label] = (
+            average_time_in_labels[label] / number_of_issues_in_labels[label]
+        )
+
+    for label in labels:
+        if label not in average_time_in_labels:
+            average_time_in_labels[label] = None
+
+    return average_time_in_labels

--- a/labels.py
+++ b/labels.py
@@ -1,0 +1,75 @@
+""" Functions for calculating time spent in labels. """
+from datetime import datetime, timedelta
+from typing import List
+
+import github3
+import pytz
+
+
+def get_label_events(
+    issue: github3.issues.Issue, labels: List[str]  # type: ignore
+) -> List[github3.issues.event]:  # type: ignore
+    """
+    Get the label events for a given issue if the label is of interest.
+
+    Args:
+        issue (github3.issues.Issue): A GitHub issue.
+        labels (List[str]): A list of labels of interest.
+
+    Returns:
+        List[github3.issues.event]: A list of label events for the given issue.
+    """
+    label_events = []
+    for event in issue.issue.events():
+        if event.event in ("labeled", "unlabeled") and event.label["name"] in labels:
+            label_events.append(event)
+
+    return label_events
+
+
+def get_label_metrics(issue: github3.issues.Issue, labels: List[str]) -> dict:  # type: ignore
+    """
+    Calculate the time spent with the given labels on a given issue.
+
+    Args:
+        issue (github3.issues.Issue): A GitHub issue.
+        labels (List[str]): A list of labels to measure time spent in.
+
+    Returns:
+        dict: A dictionary containing the time spent in each label.
+    """
+    label_metrics = {}
+    label_events = get_label_events(issue, labels)
+
+    for label in labels:
+        label_metrics[label] = timedelta(0)
+
+    # If the event is one of the labels we're looking for, add the time to the dictionary
+    unlabeled = {}
+    for event in label_events:
+        if event.event == "labeled":
+            if event.label["name"] in labels:
+                label_metrics[
+                    event.label["name"]
+                ] -= event.created_at - datetime.fromisoformat(issue.created_at)
+        elif event.event == "unlabeled":
+            unlabeled[event.label["name"]] = True
+            if event.label["name"] in labels:
+                label_metrics[
+                    event.label["name"]
+                ] += event.created_at - datetime.fromisoformat(issue.created_at)
+
+    for label in labels:
+        if label not in unlabeled:
+            # if the issue is closed, add the time from the issue creation to the closed_at time
+            if issue.state == "closed":
+                label_metrics[label] += datetime.fromisoformat(
+                    issue.closed_at
+                ) - datetime.fromisoformat(issue.created_at)
+            else:
+                # if the issue is open, add the time from the issue creation to now
+                label_metrics[label] += datetime.now(pytz.utc) - datetime.fromisoformat(
+                    issue.created_at
+                )
+
+    return label_metrics

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -143,7 +143,8 @@ def write_to_markdown(
                 file.write(f" {issue.time_to_answer} |")
             if labels and issue.label_metrics:
                 for label in labels:
-                    file.write(f" {issue.label_metrics[label]} |")
+                    if f"Time spent in {label}" in columns:
+                        file.write(f" {issue.label_metrics[label]} |")
             file.write("\n")
 
     print("Wrote issue metrics to issue_metrics.md")

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -31,12 +31,12 @@ from typing import List, Union
 from classes import IssueWithMetrics
 
 
-def get_non_hidden_columns() -> List[str]:
+def get_non_hidden_columns(labels) -> List[str]:
     """
     Get a list of the columns that are not hidden.
 
     Args:
-        None
+        labels (List[str]): A list of the labels that are used in the issues.
 
     Returns:
         List[str]: A list of the columns that are not hidden.
@@ -56,6 +56,11 @@ def get_non_hidden_columns() -> List[str]:
     if not hide_time_to_answer:
         columns.append("Time to answer")
 
+    hide_label_metrics = os.getenv("HIDE_LABEL_METRICS")
+    if not hide_label_metrics and labels:
+        for label in labels:
+            columns.append(f"Time spent in {label}")
+
     return columns
 
 
@@ -64,9 +69,10 @@ def write_to_markdown(
     average_time_to_first_response: Union[timedelta, None],
     average_time_to_close: Union[timedelta, None],
     average_time_to_answer: Union[timedelta, None],
+    average_time_in_labels: Union[dict, None],
     num_issues_opened: Union[int, None],
     num_issues_closed: Union[int, None],
-    file=None,
+    labels=None,
 ) -> None:
     """Write the issues with metrics to a markdown file.
 
@@ -76,43 +82,41 @@ def write_to_markdown(
             response for the issues.
         average_time_to_close (datetime.timedelta): The average time to close for the issues.
         average_time_to_answer (datetime.timedelta): The average time to answer the discussions.
+        average_time_in_labels (dict): A dictionary containing the average time spent in each label.
         file (file object, optional): The file object to write to. If not provided,
             a file named "issue_metrics.md" will be created.
         num_issues_opened (int): The Number of items that remain opened.
         num_issues_closed (int): The number of issues that were closed.
+        labels (List[str]): A list of the labels that are used in the issues.
 
     Returns:
         None.
 
     """
-    columns = get_non_hidden_columns()
+    columns = get_non_hidden_columns(labels)
 
     # If all the metrics are None, then there are no issues
     if not issues_with_metrics or len(issues_with_metrics) == 0:
-        with file or open("issue_metrics.md", "w", encoding="utf-8") as file:
+        with open("issue_metrics.md", "w", encoding="utf-8") as file:
             file.write("no issues found for the given search criteria\n\n")
         return
 
     # Sort the issues by time to first response
-    issues_with_metrics.sort(key=lambda x: x.time_to_first_response or timedelta.max)
-    with file or open("issue_metrics.md", "w", encoding="utf-8") as file:
+    with open("issue_metrics.md", "w", encoding="utf-8") as file:
         file.write("# Issue Metrics\n\n")
 
         # Write first table with overall metrics
-        file.write("| Metric | Value |\n")
-        file.write("| --- | ---: |\n")
-        if "Time to first response" in columns:
-            file.write(
-                f"| Average time to first response | {average_time_to_first_response} |\n"
-            )
-        if "Time to close" in columns:
-            file.write(f"| Average time to close | {average_time_to_close} |\n")
-        if "Time to answer" in columns:
-            file.write(f"| Average time to answer | {average_time_to_answer} |\n")
-        file.write(f"| Number of items that remain open | {num_issues_opened} |\n")
-        file.write(f"| Number of items closed | {num_issues_closed} |\n")
-        file.write(
-            f"| Total number of items created | {len(issues_with_metrics)} |\n\n"
+        write_overall_metrics_table(
+            issues_with_metrics,
+            average_time_to_first_response,
+            average_time_to_close,
+            average_time_to_answer,
+            average_time_in_labels,
+            num_issues_opened,
+            num_issues_closed,
+            labels,
+            columns,
+            file,
         )
 
         # Write second table with individual issue/pr/discussion metrics
@@ -137,6 +141,43 @@ def write_to_markdown(
                 file.write(f" {issue.time_to_close} |")
             if "Time to answer" in columns:
                 file.write(f" {issue.time_to_answer} |")
+            if labels and issue.label_metrics:
+                for label in labels:
+                    file.write(f" {issue.label_metrics[label]} |")
             file.write("\n")
 
     print("Wrote issue metrics to issue_metrics.md")
+
+
+def write_overall_metrics_table(
+    issues_with_metrics,
+    average_time_to_first_response,
+    average_time_to_close,
+    average_time_to_answer,
+    average_time_in_labels,
+    num_issues_opened,
+    num_issues_closed,
+    labels,
+    columns,
+    file,
+):
+    """Write the overall metrics table to the markdown file."""
+    file.write("| Metric | Value |\n")
+    file.write("| --- | ---: |\n")
+    if "Time to first response" in columns:
+        file.write(
+            f"| Average time to first response | {average_time_to_first_response} |\n"
+        )
+    if "Time to close" in columns:
+        file.write(f"| Average time to close | {average_time_to_close} |\n")
+    if "Time to answer" in columns:
+        file.write(f"| Average time to answer | {average_time_to_answer} |\n")
+    if labels and average_time_in_labels:
+        for label in labels:
+            if f"Time spent in {label}" in columns and label in average_time_in_labels:
+                file.write(
+                    f"| Average time spent in {label} | {average_time_in_labels[label]} |\n"
+                )
+    file.write(f"| Number of items that remain open | {num_issues_opened} |\n")
+    file.write(f"| Number of items closed | {num_issues_closed} |\n")
+    file.write(f"| Total number of items created | {len(issues_with_metrics)} |\n\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 github3.py==4.0.1
 python-dotenv==1.0.0
+pytz==2023.3
+Requests==2.31.0

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -218,7 +218,7 @@ class TestMain(unittest.TestCase):
         # Call main and check that it writes 'No issues found'
         issue_metrics.main()
         mock_write_to_markdown.assert_called_once_with(
-            None, None, None, None, None, None
+            None, None, None, None, None, None, None
         )
 
 
@@ -279,12 +279,14 @@ class TestGetPerIssueMetrics(unittest.TestCase):
                 timedelta(days=1),
                 None,
                 None,
+                None,
             ),
             IssueWithMetrics(
                 "Issue 2",
                 "https://github.com/user/repo/issues/2",
                 timedelta(days=2),
                 timedelta(days=3),
+                None,
                 None,
             ),
         ]

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -312,5 +312,63 @@ class TestGetPerIssueMetrics(unittest.TestCase):
         )
 
 
+class TestDiscussionMetrics(unittest.TestCase):
+    """Test suite for the discussion_metrics function."""
+
+    def setUp(self):
+        # Mock a discussion dictionary
+        self.issue1 = {
+            "title": "Issue 1",
+            "url": "github.com/user/repo/issues/1",
+            "createdAt": "2023-01-01T00:00:00Z",
+            "comments": {
+                "nodes": [
+                    {
+                        "createdAt": "2023-01-02T00:00:00Z",
+                    }
+                ]
+            },
+            "answerChosenAt": "2023-01-04T00:00:00Z",
+            "closedAt": "2023-01-05T00:00:00Z",
+        }
+
+        self.issue2 = {
+            "title": "Issue 2",
+            "url": "github.com/user/repo/issues/2",
+            "createdAt": "2023-01-01T00:00:00Z",
+            "comments": {"nodes": [{"createdAt": "2023-01-03T00:00:00Z"}]},
+            "answerChosenAt": "2023-01-05T00:00:00Z",
+            "closedAt": "2023-01-07T00:00:00Z",
+        }
+
+    def test_get_per_issue_metrics_with_discussion(self):
+        """
+        Test that the function correctly calculates
+        the metrics for a list of GitHub issues with discussions.
+        """
+
+        issues = [self.issue1, self.issue2]
+        metrics = get_per_issue_metrics(issues, discussions=True)
+
+        # get_per_issue_metrics returns a tuple of
+        # (issues_with_metrics, num_issues_open, num_issues_closed)
+        self.assertEqual(len(metrics), 3)
+
+        # Check that the metrics are correct, 0 issues open, 2 issues closed
+        self.assertEqual(metrics[1], 0)
+        self.assertEqual(metrics[2], 2)
+
+        # Check that the issues_with_metrics has 2 issues in it
+        self.assertEqual(len(metrics[0]), 2)
+
+        # Check that the issues_with_metrics has the correct metrics,
+        self.assertEqual(metrics[0][0].time_to_answer, timedelta(days=3))
+        self.assertEqual(metrics[0][0].time_to_close, timedelta(days=4))
+        self.assertEqual(metrics[0][0].time_to_first_response, timedelta(days=1))
+        self.assertEqual(metrics[0][1].time_to_answer, timedelta(days=4))
+        self.assertEqual(metrics[0][1].time_to_close, timedelta(days=6))
+        self.assertEqual(metrics[0][1].time_to_first_response, timedelta(days=2))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_json_writer.py
+++ b/test_json_writer.py
@@ -19,6 +19,9 @@ class TestWriteToJson(unittest.TestCase):
                 time_to_first_response=timedelta(days=3),
                 time_to_close=timedelta(days=6),
                 time_to_answer=None,
+                labels_metrics={
+                    "bug": timedelta(days=1, hours=16, minutes=24, seconds=12)
+                },
             ),
             IssueWithMetrics(
                 title="Issue 2",
@@ -26,6 +29,7 @@ class TestWriteToJson(unittest.TestCase):
                 time_to_first_response=timedelta(days=2),
                 time_to_close=timedelta(days=4),
                 time_to_answer=timedelta(days=1),
+                labels_metrics={},
             ),
         ]
         average_time_to_first_response = timedelta(days=2.5)
@@ -38,7 +42,7 @@ class TestWriteToJson(unittest.TestCase):
             "average_time_to_first_response": "2 days, 12:00:00",
             "average_time_to_close": "5 days, 0:00:00",
             "average_time_to_answer": "1 day, 0:00:00",
-            "average_time_in_labels": {},
+            "average_time_in_labels": {"bug": "1 day, 16:24:12"},
             "num_items_opened": 2,
             "num_items_closed": 1,
             "total_item_count": 2,
@@ -49,7 +53,7 @@ class TestWriteToJson(unittest.TestCase):
                     "time_to_first_response": "3 days, 0:00:00",
                     "time_to_close": "6 days, 0:00:00",
                     "time_to_answer": "None",
-                    "label_metrics": {},
+                    "label_metrics": {"bug": "1 day, 16:24:12"},
                 },
                 {
                     "title": "Issue 2",
@@ -69,7 +73,9 @@ class TestWriteToJson(unittest.TestCase):
                 average_time_to_first_response=average_time_to_first_response,
                 average_time_to_close=average_time_to_close,
                 average_time_to_answer=average_time_to_answer,
-                average_time_in_labels=None,
+                average_time_in_labels={
+                    "bug": timedelta(days=1, hours=16, minutes=24, seconds=12)
+                },
                 num_issues_opened=num_issues_opened,
                 num_issues_closed=num_issues_closed,
             ),

--- a/test_json_writer.py
+++ b/test_json_writer.py
@@ -38,6 +38,7 @@ class TestWriteToJson(unittest.TestCase):
             "average_time_to_first_response": "2 days, 12:00:00",
             "average_time_to_close": "5 days, 0:00:00",
             "average_time_to_answer": "1 day, 0:00:00",
+            "average_time_in_labels": {},
             "num_items_opened": 2,
             "num_items_closed": 1,
             "total_item_count": 2,
@@ -48,6 +49,7 @@ class TestWriteToJson(unittest.TestCase):
                     "time_to_first_response": "3 days, 0:00:00",
                     "time_to_close": "6 days, 0:00:00",
                     "time_to_answer": "None",
+                    "label_metrics": {},
                 },
                 {
                     "title": "Issue 2",
@@ -55,6 +57,7 @@ class TestWriteToJson(unittest.TestCase):
                     "time_to_first_response": "2 days, 0:00:00",
                     "time_to_close": "4 days, 0:00:00",
                     "time_to_answer": "1 day, 0:00:00",
+                    "label_metrics": {},
                 },
             ],
         }
@@ -62,12 +65,13 @@ class TestWriteToJson(unittest.TestCase):
         # Call the function and check the output
         self.assertEqual(
             write_to_json(
-                issues_with_metrics,
-                average_time_to_first_response,
-                average_time_to_close,
-                average_time_to_answer,
-                num_issues_opened,
-                num_issues_closed,
+                issues_with_metrics=issues_with_metrics,
+                average_time_to_first_response=average_time_to_first_response,
+                average_time_to_close=average_time_to_close,
+                average_time_to_answer=average_time_to_answer,
+                average_time_in_labels=None,
+                num_issues_opened=num_issues_opened,
+                num_issues_closed=num_issues_closed,
             ),
             json.dumps(expected_output),
         )

--- a/test_labels.py
+++ b/test_labels.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock
 
 import github3
 import pytz
+from classes import IssueWithMetrics
 
-from labels import get_label_events, get_label_metrics
+from labels import get_average_time_in_labels, get_label_events, get_label_metrics
 
 
 class TestLabels(unittest.TestCase):
@@ -65,6 +66,26 @@ class TestLabels(unittest.TestCase):
             metrics["feature"],
             datetime.now(pytz.utc) - datetime(2021, 1, 4, tzinfo=pytz.UTC),
         )
+
+
+class TestGetAverageTimeInLabels(unittest.TestCase):
+    """Unit tests for get_average_time_in_labels"""
+
+    def setUp(self):
+        self.issues_with_metrics = MagicMock()
+        self.issues_with_metrics = [
+            IssueWithMetrics(
+                "issue1", "url1", None, None, None, {"bug": timedelta(days=2)}
+            ),
+        ]
+
+    def test_get_average_time_in_labels(self):
+        """Test get_average_time_in_labels"""
+        labels = ["bug", "feature"]
+        metrics = get_average_time_in_labels(self.issues_with_metrics, labels)
+        self.assertEqual(len(metrics), 2)
+        self.assertEqual(metrics["bug"], timedelta(days=2))
+        self.assertIsNone(metrics.get("feature"))
 
 
 if __name__ == "__main__":

--- a/test_labels.py
+++ b/test_labels.py
@@ -1,0 +1,71 @@
+""" Unit tests for labels.py """
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import github3
+import pytz
+
+from labels import get_label_events, get_label_metrics
+
+
+class TestLabels(unittest.TestCase):
+    """Unit tests for labels.py"""
+
+    def setUp(self):
+        self.issue = MagicMock()  # type: ignore
+        self.issue.issue = MagicMock(spec=github3.issues.Issue)  # type: ignore
+        self.issue.created_at = "2020-01-01T00:00:00Z"
+        self.issue.closed_at = "2021-01-05T00:00:00Z"
+        self.issue.state = "closed"
+        self.issue.issue.events.return_value = [
+            MagicMock(
+                event="labeled",
+                label={"name": "bug"},
+                created_at=datetime(2021, 1, 1, tzinfo=pytz.UTC),
+            ),
+            MagicMock(
+                event="labeled",
+                label={"name": "feature"},
+                created_at=datetime(2021, 1, 2, tzinfo=pytz.UTC),
+            ),
+            MagicMock(
+                event="unlabeled",
+                label={"name": "bug"},
+                created_at=datetime(2021, 1, 3, tzinfo=pytz.UTC),
+            ),
+        ]
+
+    def test_get_label_events(self):
+        """Test get_label_events"""
+        labels = ["bug"]
+        events = get_label_events(self.issue, labels)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].label["name"], "bug")
+        self.assertEqual(events[1].label["name"], "bug")
+
+    def test_get_label_metrics_closed_issue(self):
+        """Test get_label_metrics using a closed issue"""
+        labels = ["bug", "feature"]
+        metrics = get_label_metrics(self.issue, labels)
+        self.assertEqual(metrics["bug"], timedelta(days=2))
+        self.assertEqual(metrics["feature"], timedelta(days=3))
+
+    def test_get_label_metrics_open_issue(self):
+        """Test get_label_metrics using an open issue"""
+        self.issue.state = "open"
+        labels = ["bug", "feature"]
+        metrics = get_label_metrics(self.issue, labels)
+        self.assertEqual(metrics["bug"], timedelta(days=2))
+        self.assertLess(
+            metrics["feature"],
+            datetime.now(pytz.utc) - datetime(2021, 1, 2, tzinfo=pytz.UTC),
+        )
+        self.assertGreater(
+            metrics["feature"],
+            datetime.now(pytz.utc) - datetime(2021, 1, 4, tzinfo=pytz.UTC),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -52,12 +52,13 @@ class TestWriteToMarkdown(unittest.TestCase):
 
         # Call the function
         write_to_markdown(
-            issues_with_metrics,
-            average_time_to_first_response,
-            average_time_to_close,
-            average_time_to_answer,
-            num_issues_opened,
-            num_issues_closed,
+            issues_with_metrics=issues_with_metrics,
+            average_time_to_first_response=average_time_to_first_response,
+            average_time_to_close=average_time_to_close,
+            average_time_to_answer=average_time_to_answer,
+            average_time_in_labels=None,
+            num_issues_opened=num_issues_opened,
+            num_issues_closed=num_issues_closed,
         )
 
         # Check that the function writes the correct markdown file
@@ -87,7 +88,7 @@ class TestWriteToMarkdown(unittest.TestCase):
         """Test that write_to_markdown writes the correct markdown file when no issues are found."""
         # Call the function with no issues
         with patch("builtins.open", mock_open()) as mock_open_file:
-            write_to_markdown(None, None, None, None, None, None)
+            write_to_markdown(None, None, None, None, None, None, None)
 
         # Check that the file was written correctly
         expected_output = "no issues found for the given search criteria\n\n"
@@ -143,12 +144,13 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
 
         # Call the function
         write_to_markdown(
-            issues_with_metrics,
-            average_time_to_first_response,
-            average_time_to_close,
-            average_time_to_answer,
-            num_issues_opened,
-            num_issues_closed,
+            issues_with_metrics=issues_with_metrics,
+            average_time_to_first_response=average_time_to_first_response,
+            average_time_to_close=average_time_to_close,
+            average_time_to_answer=average_time_to_answer,
+            average_time_in_labels=None,
+            num_issues_opened=num_issues_opened,
+            num_issues_closed=num_issues_closed,
         )
 
         # Check that the function writes the correct markdown file

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -35,6 +35,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 timedelta(days=1),
                 timedelta(days=2),
                 timedelta(days=3),
+                {"bug": timedelta(days=1)},
             ),
             IssueWithMetrics(
                 "Issue 2",
@@ -42,11 +43,13 @@ class TestWriteToMarkdown(unittest.TestCase):
                 timedelta(days=3),
                 timedelta(days=4),
                 timedelta(days=5),
+                {"bug": timedelta(days=2)},
             ),
         ]
         average_time_to_first_response = timedelta(days=2)
         average_time_to_close = timedelta(days=3)
         average_time_to_answer = timedelta(days=4)
+        average_time_in_labels = {"bug": "1 day, 12:00:00"}
         num_issues_opened = 2
         num_issues_closed = 1
 
@@ -56,9 +59,10 @@ class TestWriteToMarkdown(unittest.TestCase):
             average_time_to_first_response=average_time_to_first_response,
             average_time_to_close=average_time_to_close,
             average_time_to_answer=average_time_to_answer,
-            average_time_in_labels=None,
+            average_time_in_labels=average_time_in_labels,
             num_issues_opened=num_issues_opened,
             num_issues_closed=num_issues_closed,
+            labels=["bug"],
         )
 
         # Check that the function writes the correct markdown file
@@ -71,15 +75,17 @@ class TestWriteToMarkdown(unittest.TestCase):
             "| Average time to first response | 2 days, 0:00:00 |\n"
             "| Average time to close | 3 days, 0:00:00 |\n"
             "| Average time to answer | 4 days, 0:00:00 |\n"
+            "| Average time spent in bug | 1 day, 12:00:00 |\n"
             "| Number of items that remain open | 2 |\n"
             "| Number of items closed | 1 |\n"
             "| Total number of items created | 2 |\n\n"
-            "| Title | URL | Time to first response | Time to close | Time to answer |\n"
-            "| --- | --- | --- | --- | --- |\n"
+            "| Title | URL | Time to first response | Time to close |"
+            " Time to answer | Time spent in bug |\n"
+            "| --- | --- | --- | --- | --- | --- |\n"
             "| Issue 1 | https://github.com/user/repo/issues/1 | 1 day, 0:00:00 | "
-            "2 days, 0:00:00 | 3 days, 0:00:00 |\n"
+            "2 days, 0:00:00 | 3 days, 0:00:00 | 1 day, 0:00:00 |\n"
             "| Issue 2 | https://github.com/user/repo/issues/2 | 3 days, 0:00:00 | "
-            "4 days, 0:00:00 | 5 days, 0:00:00 |\n"
+            "4 days, 0:00:00 | 5 days, 0:00:00 | 2 days, 0:00:00 |\n"
         )
         self.assertEqual(content, expected_content)
         os.remove("issue_metrics.md")
@@ -106,12 +112,14 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
         os.environ["HIDE_TIME_TO_FIRST_RESPONSE"] = "True"
         os.environ["HIDE_TIME_TO_CLOSE"] = "True"
         os.environ["HIDE_TIME_TO_ANSWER"] = "True"
+        os.environ["HIDE_LABEL_METRICS"] = "True"
 
     def tearDown(self):
         # Unset the HIDE* environment variables
         os.environ.pop("HIDE_TIME_TO_FIRST_RESPONSE")
         os.environ.pop("HIDE_TIME_TO_CLOSE")
         os.environ.pop("HIDE_TIME_TO_ANSWER")
+        os.environ.pop("HIDE_LABEL_METRICS")
 
     def test_writes_markdown_file_with_non_hidden_columns_only(self):
         """
@@ -127,6 +135,9 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
                 time_to_first_response=timedelta(minutes=10),
                 time_to_close=timedelta(days=1),
                 time_to_answer=timedelta(hours=2),
+                labels_metrics={
+                    "label1": timedelta(days=1),
+                },
             ),
             IssueWithMetrics(
                 title="Issue 2",
@@ -134,11 +145,17 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
                 time_to_first_response=timedelta(minutes=20),
                 time_to_close=timedelta(days=2),
                 time_to_answer=timedelta(hours=4),
+                labels_metrics={
+                    "label1": timedelta(days=1),
+                },
             ),
         ]
         average_time_to_first_response = timedelta(minutes=15)
         average_time_to_close = timedelta(days=1.5)
         average_time_to_answer = timedelta(hours=3)
+        average_time_in_labels = {
+            "label1": timedelta(days=1),
+        }
         num_issues_opened = 2
         num_issues_closed = 1
 
@@ -148,9 +165,10 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
             average_time_to_first_response=average_time_to_first_response,
             average_time_to_close=average_time_to_close,
             average_time_to_answer=average_time_to_answer,
-            average_time_in_labels=None,
+            average_time_in_labels=average_time_in_labels,
             num_issues_opened=num_issues_opened,
             num_issues_closed=num_issues_closed,
+            labels=["label1"],
         )
 
         # Check that the function writes the correct markdown file


### PR DESCRIPTION
fixes #41

Adds option to specify a list of `LABELS_TO_MEASURE`. ie. `LABELS_TO_MEASURE = "bug,enhancement,bogus"`
Output then adds time spent in label and the average. ie (see below)

# Issue Metrics

| Metric | Value |
| --- | ---: |
| Average time to first response | 4 days, 6:28:54.625000 |
| Average time to close | 15 days, 3:41:37.090909 |
| Average time to answer | None |
| Average time spent in bug | 49 days, 1:49:59 |
| Average time spent in enhancement | 46 days, 0:39:46 |
| Average time spent in bogus | None |
| Number of items that remain open | 0 |
| Number of items closed | 11 |
| Total number of items created | 11 |

| Title | URL | Time to first response | Time to close | Time to answer | Time spent in bug | Time spent in enhancement | Time spent in bogus |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Failed to deploy to production | https://github.com/super-linter/super-linter/issues/4224 | 0:02:51 | 0:02:51 | None | None | None | None |
| Failed to deploy to production | https://github.com/super-linter/super-linter/issues/4223 | 0:03:40 | 0:03:40 | None | None | None | None |
| Support an array of default files for each linter, based on that linters expectations. | https://github.com/super-linter/super-linter/issues/4222 | 1:39:58 | 46 days, 0:40:31 | None | None | 46 days, 0:39:46 | None |
| Failed to deploy to production | https://github.com/super-linter/super-linter/issues/4221 | 0:29:38 | 0:29:38 | None | None | None | None |
| Failed to deploy to production | https://github.com/super-linter/super-linter/issues/4220 | 0:29:30 | 0:29:30 | None | None | None | None |
| [BUG] | https://github.com/super-linter/super-linter/issues/4207 | None | 2 days, 22:30:38 | None | None | None | None |
| Vivox80pro  | https://github.com/super-linter/super-linter/issues/4206 | None | 3 days, 2:14:08 | None | None | None | None |
| 1e+300 | https://github.com/super-linter/super-linter/issues/4205 | None | 3 days, 2:14:50 | None | None | None | None |
| Failed to deploy to production | https://github.com/super-linter/super-linter/issues/4204 | 1:30:22 | 1:30:22 | None | None | None | None |
| Failed to deploy to production | https://github.com/super-linter/super-linter/issues/4203 | 7 days, 5:48:59 | 49 days, 3:24:45 | None | 49 days, 1:49:59 | None | None |
| pulling the super linter docker image is taking long time even if we use slim image (around one and half min). tried caching the image but size of the image is too long and for restoring the image also taking long time.  Is there any way to improve the time? | https://github.com/super-linter/super-linter/issues/4186 | 26 days, 17:46:19 | 62 days, 6:56:55 | None | None | None | None |
