### PR TITLE
fix: release drafter to use proper labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,13 +29,13 @@ change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 version-resolver:
   major:
     labels:
-      - 'type: breaking'
+      - 'breaking'
   minor:
     labels:
-      - 'type: enhancement'
+      - 'enhancement'
   patch:
     labels:
-      - 'type: bug'
-      - 'type: maintenance'
-      - 'type: documentation'
+      - 'bug'
+      - 'maintenance'
+      - 'documentation'
   default: patch


### PR DESCRIPTION
Currently the release drafter is not properly incrementing the version numbers and is creating extra manual work. This is caused by the configuration file changed in this pull request not looking for the labels that this project actually uses. 

This pull request changes the label to match the ones used in this project.