### PR TITLE
Trim issue titles

### DIFF
--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -136,6 +136,8 @@ def write_to_markdown(
         for issue in issues_with_metrics:
             # Replace the vertical bar with the HTML entity
             issue.title = issue.title.replace("|", "&#124;")
+            # Replace any trailing whitespace
+            issue.title = issue.title.strip()
 
             file.write(f"| " f"{issue.title} | " f"{issue.html_url} |")
             if "Time to first response" in columns:

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -136,7 +136,7 @@ def write_to_markdown(
         for issue in issues_with_metrics:
             # Replace the vertical bar with the HTML entity
             issue.title = issue.title.replace("|", "&#124;")
-            # Replace any trailing whitespace
+            # Replace any whitespace
             issue.title = issue.title.strip()
 
             file.write(f"| " f"{issue.title} | " f"{issue.html_url} |")

--- a/test_labels.py
+++ b/test_labels.py
@@ -58,7 +58,7 @@ class TestLabels(unittest.TestCase):
         labels = ["bug", "feature"]
         metrics = get_label_metrics(self.issue, labels)
         self.assertEqual(metrics["bug"], timedelta(days=2))
-        self.assertLess(
+        self.assertLessEqual(
             metrics["feature"],
             datetime.now(pytz.utc) - datetime(2021, 1, 2, tzinfo=pytz.UTC),
         )

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -38,7 +38,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 {"bug": timedelta(days=1)},
             ),
             IssueWithMetrics(
-                "Issue 2",
+                "Issue 2\r",
                 "https://github.com/user/repo/issues/2",
                 timedelta(days=3),
                 timedelta(days=4),


### PR DESCRIPTION
Somehow I managed to create a series of issues last month (I assume some weird copy-paste thing) that contained `\r` at the end of their titles. For example, [this pull request](https://api.github.com/repos/martincostello/update-static-assets/pulls/282), of which here's a snippet:

```jsonc
{
  "url": "https://api.github.com/repos/martincostello/update-static-assets/pulls/282",
  "id": 1454674049,
  "node_id": "PR_kwDOHxs9d85WtJCB",
  "html_url": "https://github.com/martincostello/update-static-assets/pull/282",
  "number": 282,
  "state": "closed",
  "title": "Add actionlint\r", // <-- No idea how I managed to do this!
  "user": {
    "login": "martincostello"
  }
}
```

This then causes the Markdown table rendering to break ([example](https://github.com/martincostello/github-automation/actions/runs/5735630789), notice the PR links starting to appear in the first column).

This pull request fixes that by trimming the issue title before rendering.

It also fixes a test assertion that is failing on my computer even without these changes. As I'm based in London, I assume that makes me equal to UTC here (even though we're currently in Daylight Savings at GMT+1)?