### PR TITLE
Authenticate to GitHub Enterprise Server instances

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -121,7 +121,9 @@ def auth_to_github() -> github3.GitHub:
         github3.GitHub: A github api connection.
     """
     if token := os.getenv("GH_TOKEN"):
-        if os.getenv("GITHUB_SERVER_URL") == 'https://github.com':
+        if not os.getenv("GITHUB_SERVER_URL"):
+            github_connection = github3.login(token=token)
+        elif os.getenv("GITHUB_SERVER_URL") == 'https://github.com':
             github_connection = github3.login(token=token)
         else:
             github_connection = github3.GitHubEnterprise(os.getenv("GITHUB_SERVER_URL"),token=token)

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -121,7 +121,10 @@ def auth_to_github() -> github3.GitHub:
         github3.GitHub: A github api connection.
     """
     if token := os.getenv("GH_TOKEN"):
-        github_connection = github3.login(token=token)
+        if os.getenv("GITHUB_SERVER_URL") == 'https://github.com':
+            github_connection = github3.login(token=token)
+        else:
+            github_connection = github3.GitHubEnterprise(os.getenv("GITHUB_SERVER_URL")).login(token=token)
     else:
         raise ValueError("GH_TOKEN environment variable not set")
 

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -124,7 +124,7 @@ def auth_to_github() -> github3.GitHub:
         if os.getenv("GITHUB_SERVER_URL") == 'https://github.com':
             github_connection = github3.login(token=token)
         else:
-            github_connection = github3.GitHubEnterprise(os.getenv("GITHUB_SERVER_URL")).login(token=token)
+            github_connection = github3.GitHubEnterprise(os.getenv("GITHUB_SERVER_URL"),token=token)
     else:
         raise ValueError("GH_TOKEN environment variable not set")
 


### PR DESCRIPTION
Resolving #90 

Simply checks the GITHUB_SERVER_URL environment variable, if it's set to github.com it will use the default login, otherwise it uses the GitHub Enterprise Server specific connection function.

Validated against my company's GitHub Enterprise Server instance, can't really show the output because of the proprietary nature of how the logs look. If there's a good bit of evidence you want for that that I can provide, let me know.