### PR TITLE
fix: fix time to first response

### DIFF
--- a/test_time_to_first_response.py
+++ b/test_time_to_first_response.py
@@ -33,12 +33,14 @@ class TestMeasureTimeToFirstResponse(unittest.TestCase):
         """
         # Set up the mock GitHub issues
         mock_issue1 = MagicMock()
-        mock_issue1.comments = 1
+        mock_issue1.comments = 2
         mock_issue1.created_at = "2023-01-01T00:00:00Z"
 
         mock_comment1 = MagicMock()
         mock_comment1.created_at = datetime.fromisoformat("2023-01-02T00:00:00Z")
-        mock_issue1.issue.comments.return_value = [mock_comment1]
+        mock_comment2 = MagicMock()
+        mock_comment2.created_at = datetime.fromisoformat("2023-01-02T12:00:00Z")
+        mock_issue1.issue.comments.return_value = [mock_comment1, mock_comment2]
 
         # Call the function
         result = measure_time_to_first_response(mock_issue1, None)
@@ -105,7 +107,9 @@ class TestMeasureTimeToFirstResponse(unittest.TestCase):
         mock_issue1.issue.comments.return_value = [mock_comment1, mock_comment2]
 
         # Call the function
-        result = measure_time_to_first_response(mock_issue1, None, ["ignored_user", "ignored_user2"])
+        result = measure_time_to_first_response(
+            mock_issue1, None, ["ignored_user", "ignored_user2"]
+        )
         expected_result = None
 
         # Check the results

--- a/time_to_first_response.py
+++ b/time_to_first_response.py
@@ -56,6 +56,7 @@ def measure_time_to_first_response(
             if comment.user.login in ignore_users:
                 continue
             first_comment_time = comment.created_at
+            break
 
         # Check if the issue is actually a pull request
         # so we may also get the first review comment time
@@ -66,6 +67,7 @@ def measure_time_to_first_response(
                 if review_comment.user.login in ignore_users:
                     continue
                 first_review_comment_time = review_comment.submitted_at
+                break
 
         # Figure out the earliest response timestamp
         if first_comment_time and first_review_comment_time:


### PR DESCRIPTION
Right now time to first response on issues is calculated incorrectly as `first_review_comment_time` and `first_review_comment_time` are being overwritten by data from later comments.