### PR TITLE
Fix: Modified parameters to follow to API specifications

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -83,7 +83,7 @@ def search_issues(
         List[github3.search.IssueSearchResult]: A list of issues that match the search query.
     """
     print("Searching for issues...")
-    issues_iterator = github_connection.search_issues(search_query, per_page=200)
+    issues_iterator = github_connection.search_issues(search_query, per_page=100)
 
     # Print the issue titles
     issues = []


### PR DESCRIPTION
# What was changed

Fixed `per_page` parameter to follow to the API specifications.

The parameter of `per_page` is allowed under the value of 100 as below document.
https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues