### PR TITLE
docs(readme): document how to ignore bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Below are the allowed configuration options:
 | `HIDE_TIME_TO_CLOSE` | False |         | If set to any value, the time to close will not be displayed in the generated markdown file. |
 | `HIDE_TIME_TO_ANSWER` | False |         | If set to any value, the time to answer a discussion will not be displayed in the generated markdown file. |
 | `HIDE_LABEL_METRICS` | False |         | If set to any value, the time in label metrics will not be displayed in the generated markdown file. |
-| `IGNORE_USERS` | False |         | A comma separated list of users to ignore when calculating metrics. (ie. `IGNORE_USERS: 'user1,user2'`) |
+| `IGNORE_USERS` | False |         | A comma separated list of users to ignore when calculating metrics. (ie. `IGNORE_USERS: 'user1,user2'`). To ignore bots, append `[bot]` to the user (ie. `IGNORE_USERS: 'github-actions[bot]'`)  |
 
 ### Example workflows
 


### PR DESCRIPTION
Updates the `IGNORE_USERS` configuration to document how bots and Github apps can be ignored from the `time to first response` calculation. 