### PR TITLE
Feature: Ignore PR time spent as draft, measure PRs by merge time

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ several metrics. The issues/pull requests/discussions to search for can be filte
 The metrics that are measured are:
 | Metric | Description |
 |--------|-------------|
-| Time to first response | The time between when an issue/pull request/discussion is created and when the first comment or review is made. |
-| Time to close | The time between when an issue/pull request/discussion is created and when it is closed. |
+| Time to first response | The time between when an issue/pull request/discussion is created and when the first comment or review is made.* |
+| Time to close | The time between when an issue/pull request/discussion is created and when it is closed.* |
 | Time to answer | (Discussions only) The time between when a discussion is created and when it is answered. |
 | Time in label | The time between when a label has a specific label applied to an issue/pull request/discussion and when it is removed. This requires the LABELS_TO_MEASURE env variable to be set. |
+
+*For pull requests, these metrics exclude the time the PR was in draft mode.
 
 This action was developed by the GitHub OSPO for our own use and developed in a way that we could open source it that it might be useful to you as well! If you want to know more about how we use it, reach out in an issue in this repository.
 

--- a/test_time_to_merge.py
+++ b/test_time_to_merge.py
@@ -1,0 +1,51 @@
+"""A module containing unit tests for the time_to_merge module.
+
+This module contains unit tests for the measure_time_to_merge
+function in the time_to_merge module.
+The tests use mock GitHub pull request to test the function's behavior.
+
+Classes:
+    TestMeasureTimeToMerge: A class to test the measure_time_to_merge function.
+
+"""
+from datetime import timedelta, datetime
+import unittest
+from unittest.mock import MagicMock
+
+from time_to_merge import measure_time_to_merge
+
+class TestMeasureTimeToMerge(unittest.TestCase):
+    """Test suite for the measure_time_to_merge function."""
+
+    def test_measure_time_to_merge_ready_for_review(self):
+        """Test that the function correctly measures the time to merge a pull request that was formerly a draft."""
+        # Create a mock pull request object
+        pull_request = MagicMock()
+        pull_request.merged_at = datetime.fromisoformat("2021-01-03T00:00:00Z")
+        ready_for_review_at = datetime.fromisoformat("2021-01-01T00:00:00Z")
+
+        # Call the function and check the result
+        result = measure_time_to_merge(pull_request, ready_for_review_at)
+        expected_result = timedelta(days=2)
+        self.assertEqual(result, expected_result)
+
+    def test_measure_time_to_merge_created_at(self):
+        """Test that the function correctly measures the time to merge a pull request that was never a draft."""
+        # Create a mock pull request object
+        pull_request = MagicMock()
+        pull_request.merged_at = datetime.fromisoformat("2021-01-03T00:00:00Z")
+        pull_request.created_at = datetime.fromisoformat("2021-01-01T00:00:00Z")
+
+        # Call the function and check the result
+        result = measure_time_to_merge(pull_request, None)
+        expected_result = timedelta(days=2)
+        self.assertEqual(result, expected_result)
+
+    def test_measure_time_to_merge_returns_none(self):
+        """Test that the function returns None if the pull request is not merged."""
+        # Create a mock issue object
+        pull_request = MagicMock()
+        pull_request.merged_at = None
+
+        # Call the function and check that it returns None
+        self.assertEqual(None, measure_time_to_merge(pull_request, None))

--- a/test_time_to_ready_for_review.py
+++ b/test_time_to_ready_for_review.py
@@ -1,0 +1,57 @@
+"""A module containing unit tests for the time_to_ready_for_review module.
+
+This module contains unit tests for the get_time_to_ready_for_review
+function in the time_to_ready_for_review module.
+The tests use mock GitHub issues to test the functions' behavior.
+
+Classes:
+    TestGetTimeToReadyForReview: A class to test the get_time_to_ready_for_review function.
+
+"""
+from datetime import datetime
+import unittest
+from unittest.mock import MagicMock
+
+from time_to_ready_for_review import get_time_to_ready_for_review
+
+class TestGetTimeToReadyForReview(unittest.TestCase):
+    """Test suite for the get_time_to_ready_for_review function."""
+
+    # def draft pr function
+    def test_time_to_ready_for_review_draft(self):
+        """Test that the function returns None when the pull request is a draft"""
+        pull_request = MagicMock()
+        pull_request.draft = True
+        issue = MagicMock()
+
+        result = get_time_to_ready_for_review(issue, pull_request)
+        expected_result = None
+        self.assertEqual(result, expected_result)
+
+    def test_get_time_to_ready_for_review_event(self):
+        """Test that the function correctly gets the time a pull request was marked as ready for review"""
+        pull_request = MagicMock()
+        pull_request.draft = False
+        event = MagicMock()
+        event.event = 'ready_for_review'
+        event.created_at = datetime.fromisoformat("2021-01-01T00:00:00Z")
+        issue = MagicMock()
+        issue.issue.events.return_value=[event]
+        
+        result = get_time_to_ready_for_review(issue, pull_request)
+        expected_result = event.created_at
+        self.assertEqual(result, expected_result)
+
+    def test_get_time_to_ready_for_review_no_event(self):
+        """Test that the function returns None when the pull request is not a draft and no ready_for_review event is found"""
+        pull_request = MagicMock()
+        pull_request.draft = False
+        event = MagicMock()
+        event.event = 'foobar'
+        event.created_at = "2021-01-01T00:00:00Z"
+        issue = MagicMock()
+        issue.events.return_value=[event]
+
+        result = get_time_to_ready_for_review(issue, pull_request)
+        expected_result = None
+        self.assertEqual(result, expected_result)

--- a/time_to_merge.py
+++ b/time_to_merge.py
@@ -1,0 +1,43 @@
+"""A module for measuring the time it takes to merge a GitHub pull request.
+
+This module provides functions for measuring the time it takes to merge a GitHub pull
+request, as well as calculating the average time to merge for a list of pull requests.
+
+Functions:
+    measure_time_to_merge(
+        pull_request: github3.pulls.PullRequest,
+        ready_for_review_at: Union[datetime, None]
+    ) -> Union[timedelta, None]:
+        Measure the time it takes to merge a pull request.
+
+"""
+from datetime import datetime, timedelta
+from typing import List, Union
+
+import github3
+
+def measure_time_to_merge(
+    pull_request: github3.pulls.PullRequest,
+    ready_for_review_at: Union[datetime, None]
+) -> Union[timedelta, None]:
+    """Measure the time it takes to merge a pull request.
+
+    Args:
+        pull_request (github3.pulls.PullRequest): A GitHub pull request.
+        ready_for_review_at (Union[timedelta, None]): When the PR was marked as ready for review 
+
+    Returns:
+        Union[datetime.timedelta, None]: The time it takes to close the issue.
+
+    """
+    merged_at = None
+    if pull_request.merged_at is None:
+        return None
+
+    merged_at = pull_request.merged_at
+
+    if ready_for_review_at:
+        return merged_at - ready_for_review_at
+
+    created_at = pull_request.created_at
+    return merged_at - created_at

--- a/time_to_ready_for_review.py
+++ b/time_to_ready_for_review.py
@@ -1,0 +1,44 @@
+"""A module for getting the time a pull request was marked as ready for review
+after being in draft mode.
+
+This module provides functions for getting the time a GitHub pull request was
+marked as ready for review, if it was formerly in draft mode.
+
+Functions:
+    get_time_to_ready_for_review(
+        issue: github3.issues.Issue,
+        pull_request: github3.pulls.PullRequest
+    ) -> Union[datetime, None]:
+        If a pull request was formerly a draft, get the time it was marked as
+        ready for review.
+
+"""
+
+from datetime import datetime
+from typing import Union
+
+import github3
+
+def get_time_to_ready_for_review(
+    issue: github3.issues.Issue,
+    pull_request: github3.pulls.PullRequest
+) -> Union[datetime, None]:
+    """If a pull request was formerly a draft, get the time it was marked as ready
+    for review
+    
+    Args:
+        issue (github3.issues.Issue): A GitHub issue.
+        pull_request (github3.pulls.PullRequest): A GitHub pull request.
+
+    Returns:
+        Union[datetime, None]: The time the pull request was marked as ready for review
+    """
+    if pull_request.draft:
+        return None
+
+    events = issue.issue.events(number=50)
+    for event in events:
+        if event.event == 'ready_for_review':
+            return event.created_at
+
+    return None


### PR DESCRIPTION
# What's the feature?
Excludes the time a pull request was in draft mode when calculating how long it was open for, and uses the time a PR was merged as the time the issue was closed.

# How does it work?
* If an issue is a pull request, grab when it was marked as Ready for Review
    * To measure this, it grabs the first 50 [events](https://docs.github.com/en/rest/issues/events?apiVersion=2022-11-28) and looks for one called "Ready for Review".
    * If it can't find it, subsequent steps will assume the PR was never a draft and will just use the Created time
* `measure_time_to_first_response` now excludes comments/reviews made before the PR was marked as Ready for Review
* Instead of calling `measure_time_to_close`, PRs now use `measure_time_to_merge` which will key off of the Ready for Review time (if one was found)

If the user would like to exclude active drafts from the search results as well, they can add `draft:false` to their search query

This should resolve #37 