### PR TITLE
update: Makefile, .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,10 @@
+[MAIN]
+ignore=.git,
+	__pycache__,
+	venv,
+	.venv,
+
+
 [MESSAGES CONTROL]
 disable=
 	redefined-argument-from-local,

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 .PHONY: lint
 lint:
 	# stop the build if there are Python syntax errors or undefined names
-	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=venv,.venv,.git,__pycache__
 	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-	flake8 . --count --exit-zero --max-complexity=15 --max-line-length=127 --statistics
+	flake8 . --count --exit-zero --max-complexity=15 --max-line-length=127 --statistics --exclude=venv,.venv,.git,__pycache__
 	pylint --rcfile=.pylintrc --fail-under=9.0 *.py


### PR DESCRIPTION
close #112 

## What changes were made?

During the lint execution, certain folders have been excluded. This change brings about the following benefits:

- Those who develop this project might experience shorter lint execution times.
- The execution time of the CI performing the lint might be slightly reduced (though this will likely be minimal).