### PR TITLE
Exclude bot's comment from "Time to first response"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The metrics that are measured are:
 | Time to answer | (Discussions only) The time between when a discussion is created and when it is answered. |
 | Time in label | The time between when a label has a specific label applied to an issue/pull request/discussion and when it is removed. This requires the LABELS_TO_MEASURE env variable to be set. |
 
-*For pull requests, these metrics exclude the time the PR was in draft mode.
+*For pull requests, these metrics exclude the time the PR was in draft mode.  
+*For Issue and pull requests, issue/pull request author's own comments and comments by bots are excluded.
 
 This action was developed by the GitHub OSPO for our own use and developed in a way that we could open source it that it might be useful to you as well! If you want to know more about how we use it, reach out in an issue in this repository.
 

--- a/test_time_to_first_response.py
+++ b/test_time_to_first_response.py
@@ -280,6 +280,36 @@ class TestMeasureTimeToFirstResponse(unittest.TestCase):
         # Check the results
         self.assertEqual(result, expected_result)
 
+    def test_measure_time_to_first_response_ignore_bot(self):
+        """Test that measure_time_to_first_response ignore bot's comment."""
+        # Set up the mock GitHub issues
+        mock_issue1 = MagicMock()
+        mock_issue1.comments = 2
+        mock_issue1.created_at = "2023-01-01T00:00:00Z"
+
+        # Set up the mock GitHub issue comments
+        mock_comment1 = MagicMock()
+        mock_comment1.user.type = "Bot"
+        mock_comment1.created_at = datetime.fromisoformat("2023-01-02T00:00:00Z")
+        mock_issue1.issue.comments.return_value = [mock_comment1]
+
+        # Set up the mock GitHub pull request comments
+        mock_pr_comment1 = MagicMock()
+        mock_pr_comment1.user.type = "Bot"
+        mock_pr_comment1.submitted_at = datetime.fromisoformat("2023-01-03T00:00:00Z")
+        mock_pr_comment2 = MagicMock()
+        mock_pr_comment2.user.type = "User"
+        mock_pr_comment2.submitted_at = datetime.fromisoformat("2023-01-04T00:00:00Z")  # first response
+        mock_pull_request = MagicMock()
+        mock_pull_request.reviews.return_value = [mock_pr_comment1, mock_pr_comment2]
+
+        # Call the function
+        result = measure_time_to_first_response(mock_issue1, None, mock_pull_request, None)
+        expected_result = timedelta(days=3)
+
+        # Check the results
+        self.assertEqual(result, expected_result)
+
 
 class TestGetAverageTimeToFirstResponse(unittest.TestCase):
     """Test the get_average_time_to_first_response function."""

--- a/time_to_first_response.py
+++ b/time_to_first_response.py
@@ -59,6 +59,8 @@ def measure_time_to_first_response(
         for comment in comments:
             if comment.user.login in ignore_users:
                 continue
+            if comment.user.type == "Bot":
+                continue
             if comment.user.login == issue.issue.user.login:
                 continue
             if ready_for_review_at and comment.created_at < ready_for_review_at:
@@ -72,6 +74,8 @@ def measure_time_to_first_response(
             review_comments = pull_request.reviews(number=50)  # type: ignore
             for review_comment in review_comments:
                 if review_comment.user.login in ignore_users:
+                    continue
+                if review_comment.user.type == "Bot":
                     continue
                 if review_comment.user.login == issue.issue.user.login:
                     continue


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

<!-- Describe what the changes are -->

## Proposed Changes
Exclude bot's comment from "Time to first response".

I believe that bots in GitHub actions often respond faster than users, so it's hard to imagine a use case where measuring the time it takes for a bot to respond would be useful.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
