### PR TITLE
Documentation: Add required python version to docs and test deps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ jobs:
 
 ## Local usage without Docker
 
+1. Make sure you have at least Python3.11 installed
 1. Copy `.env-example` to `.env`
 1. Fill out the `.env` file with a _token_ from a user that has access to the organization to scan (listed below). Tokens should have admin:org or read:org access.
 1. Fill out the `.env` file with the _search_query_ to filter issues by

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ github3.py==4.0.1
 python-dotenv==1.0.0
 pytz==2023.3.post1
 Requests==2.31.0
+pytest==7.4.2
+pytest-cov==4.1.0


### PR DESCRIPTION
When running `make test` for the first time on a machine not regularly used for building and testing python code chances are high that pytest and pytest-cov aren't installed. This add them as a dependency to requirements.txt.

Also adding information on minimum python version to run the code. With python3.10 I ran into the error message

`TypeError: Parameters to generic types must be types. Got <module 'github3.issues.event'`

With python3.11 this error was gone.


- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking` (<- the project doesn't let me change labels, likely as a contributor I don't have the karma to do that?)
