### PR TITLE
feat: add author column

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Here is the output with no hidden columns:
 
 | Title | URL | Author | Time to first response | Time to close | Time to answer |
 | --- | --- | --- | --- | --- | --- |
-| Discussion Title 1 | https://github.com/user/repo/discussions/1 | alice | 0:00:41 | 6 days, 7:08:52 | 1 day |
+| Discussion Title 1 | https://github.com/user/repo/discussions/1 | None | 0:00:41 | 6 days, 7:08:52 | 1 day |
 | Pull Request Title 2 | https://github.com/user/repo/pulls/2 | bob | 0:05:26 | None | None |
 | Issue Title 3 | https://github.com/user/repo/issues/3 | carol | 2:26:07 | None | None |
 
@@ -366,7 +366,7 @@ Here is the output with all hidable columns hidden:
 
 | Title | URL | Author |
 | --- | --- | --- |
-| Discussion Title 1 | https://github.com/user/repo/discussions/1 | alice |
+| Discussion Title 1 | https://github.com/user/repo/discussions/1 | None |
 | Pull Request Title 2 | https://github.com/user/repo/pulls/2 | bob |
 | Issue Title 3 | https://github.com/user/repo/issues/3 | carol |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The metrics that are measured are:
 | Time to answer | (Discussions only) The time between when a discussion is created and when it is answered. |
 | Time in label | The time between when a label has a specific label applied to an issue/pull request/discussion and when it is removed. This requires the LABELS_TO_MEASURE env variable to be set. |
 
-*For pull requests, these metrics exclude the time the PR was in draft mode.  
+*For pull requests, these metrics exclude the time the PR was in draft mode.
 *For Issue and pull requests, issue/pull request author's own comments and comments by bots are excluded.
 
 This action was developed by the GitHub OSPO for our own use and developed in a way that we could open source it that it might be useful to you as well! If you want to know more about how we use it, reach out in an issue in this repository.
@@ -324,10 +324,10 @@ then the report will look like this:
 | Number of items closed | 1 |
 | Total number of items created | 3 |
 
-| Title | URL | Time to first response | Time to close | Time to answer | Time spent in waiting-for-manager-approval | Time spent in waiting-for-security-review |
-| --- | --- | --- | --- | --- | --- | --- |
-| Pull Request Title 1 | https://github.com/user/repo/pulls/1 | 0:05:26 | None | None | None | None |
-| Issue Title 2 | https://github.com/user/repo/issues/2 | 2:26:07 | None | None | 0:00:41 | 2 days, 4:25:03 |
+| Title | URL | Author | Time to first response | Time to close | Time to answer | Time spent in waiting-for-manager-approval | Time spent in waiting-for-security-review |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Pull Request Title 1 | https://github.com/user/repo/pulls/1 | alice | 0:05:26 | None | None | None | None |
+| Issue Title 2 | https://github.com/user/repo/issues/2 | bob | 2:26:07 | None | None | 0:00:41 | 2 days, 4:25:03 |
 
 ```
 
@@ -346,11 +346,11 @@ Here is the output with no hidden columns:
 | Number of items closed | 1 |
 | Total number of items created | 3 |
 
-| Title | URL | Time to first response | Time to close | Time to answer |
-| --- | --- | --- | --- | --- |
-| Discussion Title 1 | https://github.com/user/repo/discussions/1 | 0:00:41 | 6 days, 7:08:52 | 1 day |
-| Pull Request Title 2 | https://github.com/user/repo/pulls/2 | 0:05:26 | None | None |
-| Issue Title 3 | https://github.com/user/repo/issues/3 | 2:26:07 | None | None |
+| Title | URL | Author | Time to first response | Time to close | Time to answer |
+| --- | --- | --- | --- | --- | --- |
+| Discussion Title 1 | https://github.com/user/repo/discussions/1 | alice | 0:00:41 | 6 days, 7:08:52 | 1 day |
+| Pull Request Title 2 | https://github.com/user/repo/pulls/2 | bob | 0:05:26 | None | None |
+| Issue Title 3 | https://github.com/user/repo/issues/3 | carol | 2:26:07 | None | None |
 
 ```
 
@@ -364,11 +364,11 @@ Here is the output with all hidable columns hidden:
 | Number of items closed | 1 |
 | Total number of items created | 3 |
 
-| Title | URL |
-| --- | --- |
-| Discussion Title 1 | https://github.com/user/repo/discussions/1 |
-| Pull Request Title 2 | https://github.com/user/repo/pulls/2 |
-| Issue Title 3 | https://github.com/user/repo/issues/3 |
+| Title | URL | Author |
+| --- | --- | --- |
+| Discussion Title 1 | https://github.com/user/repo/discussions/1 | alice |
+| Pull Request Title 2 | https://github.com/user/repo/pulls/2 | bob |
+| Issue Title 3 | https://github.com/user/repo/issues/3 | carol |
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Below are the allowed configuration options:
 | `GH_TOKEN`            | True     |         | The GitHub Token used to scan the repository. Must have read access to all repository you are interested in scanning. |
 | `SEARCH_QUERY`        | True     |         | The query by which you can filter issues/prs which must contain a `repo:`, `org:`, `owner:`, or a `user:` entry. For discussions, include `type:discussions` in the query. |
 | `LABELS_TO_MEASURE`   | False    |         | A comma separated list of labels to measure how much time the label is applied. If not provided, no labels durations will be measured. Not compatible with discussions at this time. |
+| `HIDE_AUTHOR` | False |         | If set to any value, the author will not be displayed in the generated markdown file. |
 | `HIDE_TIME_TO_FIRST_RESPONSE` | False |         | If set to any value, the time to first response will not be displayed in the generated markdown file. |
 | `HIDE_TIME_TO_CLOSE` | False |         | If set to any value, the time to close will not be displayed in the generated markdown file. |
 | `HIDE_TIME_TO_ANSWER` | False |         | If set to any value, the time to answer a discussion will not be displayed in the generated markdown file. |

--- a/classes.py
+++ b/classes.py
@@ -12,6 +12,7 @@ class IssueWithMetrics:
     Attributes:
         title (str): The title of the issue.
         html_url (str): The URL of the issue on GitHub.
+        author (str): The author of the issue.
         time_to_first_response (timedelta, optional): The time it took to
             get the first response to the issue.
         time_to_close (timedelta, optional): The time it took to close the issue.
@@ -25,7 +26,7 @@ class IssueWithMetrics:
         self,
         title,
         html_url,
-        author=None,
+        author,
         time_to_first_response=None,
         time_to_close=None,
         time_to_answer=None,

--- a/classes.py
+++ b/classes.py
@@ -25,6 +25,7 @@ class IssueWithMetrics:
         self,
         title,
         html_url,
+        author=None,
         time_to_first_response=None,
         time_to_close=None,
         time_to_answer=None,
@@ -32,6 +33,7 @@ class IssueWithMetrics:
     ):
         self.title = title
         self.html_url = html_url
+        self.author = author
         self.time_to_first_response = time_to_first_response
         self.time_to_close = time_to_close
         self.time_to_answer = time_to_answer

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -176,6 +176,7 @@ def get_per_issue_metrics(
                 None,
                 None,
                 None,
+                None,
             )
             issue_with_metrics.time_to_first_response = measure_time_to_first_response(
                 None, issue, ignore_users
@@ -190,6 +191,7 @@ def get_per_issue_metrics(
             issue_with_metrics = IssueWithMetrics(
                 issue.title,  # type: ignore
                 issue.html_url,  # type: ignore
+                None,
                 None,
                 None,
                 None,

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -172,7 +172,7 @@ def get_per_issue_metrics(
             issue_with_metrics = IssueWithMetrics(
                 issue["title"],
                 issue["url"],
-                None,
+                issue["user"]["login"],
                 None,
                 None,
                 None,
@@ -191,7 +191,7 @@ def get_per_issue_metrics(
             issue_with_metrics = IssueWithMetrics(
                 issue.title,  # type: ignore
                 issue.html_url,  # type: ignore
-                None,
+                issue.user["login"],  # type: ignore
                 None,
                 None,
                 None,

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -172,7 +172,7 @@ def get_per_issue_metrics(
             issue_with_metrics = IssueWithMetrics(
                 issue["title"],
                 issue["url"],
-                issue["user"]["login"],
+                None,
                 None,
                 None,
                 None,

--- a/json_writer.py
+++ b/json_writer.py
@@ -48,6 +48,7 @@ def write_to_json(
             {
                 "title": "Issue 1",
                 "html_url": "https://github.com/owner/repo/issues/1",
+                "author": "author",
                 "time_to_first_response": "3 days, 0:00:00",
                 "time_to_close": "6 days, 0:00:00",
                 "time_to_answer": "None",
@@ -58,6 +59,7 @@ def write_to_json(
             {
                 "title": "Issue 2",
                 "html_url": "https://github.com/owner/repo/issues/2",
+                "author": "author",
                 "time_to_first_response": "2 days, 0:00:00",
                 "time_to_close": "4 days, 0:00:00",
                 "time_to_answer": "1 day, 0:00:00",
@@ -100,6 +102,7 @@ def write_to_json(
             {
                 "title": issue.title,
                 "html_url": issue.html_url,
+                "author": issue.author,
                 "time_to_first_response": str(issue.time_to_first_response),
                 "time_to_close": str(issue.time_to_close),
                 "time_to_answer": str(issue.time_to_answer),

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -42,8 +42,12 @@ def get_non_hidden_columns(labels) -> List[str]:
         List[str]: A list of the columns that are not hidden.
 
     """
-    columns = ["Title", "URL", "Author"]
+    columns = ["Title", "URL"]
     # Find the number of columns and which are to be hidden
+    hide_author = os.getenv("HIDE_AUTHOR")
+    if not hide_author:
+        columns.append("Author")
+
     hide_time_to_first_response = os.getenv("HIDE_TIME_TO_FIRST_RESPONSE")
     if not hide_time_to_first_response:
         columns.append("Time to first response")
@@ -141,7 +145,9 @@ def write_to_markdown(
             # Replace any whitespace
             issue.title = issue.title.strip()
 
-            file.write(f"| " f"{issue.title} | " f"{issue.html_url} |" f" {issue.author} |")
+            file.write(f"| " f"{issue.title} | " f"{issue.html_url} |")
+            if "Author" in columns:
+                file.write(f" {issue.author} |")
             if "Time to first response" in columns:
                 file.write(f" {issue.time_to_first_response} |")
             if "Time to close" in columns:

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -42,7 +42,7 @@ def get_non_hidden_columns(labels) -> List[str]:
         List[str]: A list of the columns that are not hidden.
 
     """
-    columns = ["Title", "URL"]
+    columns = ["Title", "URL", "Author"]
     # Find the number of columns and which are to be hidden
     hide_time_to_first_response = os.getenv("HIDE_TIME_TO_FIRST_RESPONSE")
     if not hide_time_to_first_response:
@@ -141,7 +141,7 @@ def write_to_markdown(
             # Replace any whitespace
             issue.title = issue.title.strip()
 
-            file.write(f"| " f"{issue.title} | " f"{issue.html_url} |")
+            file.write(f"| " f"{issue.title} | " f"{issue.html_url} |" f" {issue.author} |")
             if "Time to first response" in columns:
                 file.write(f" {issue.time_to_first_response} |")
             if "Time to close" in columns:

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -167,11 +167,13 @@ class TestMain(unittest.TestCase):
             (
                 "Issue 1",
                 "https://github.com/user/repo/issues/1",
+                "alice",
                 timedelta(days=1, hours=2, minutes=30),
             ),
             (
                 "Issue 2",
                 "https://github.com/user/repo/issues/2",
+                "bob",
                 timedelta(days=3, hours=4, minutes=30),
             ),
         ]
@@ -231,6 +233,7 @@ class TestGetPerIssueMetrics(unittest.TestCase):
         mock_issue1 = MagicMock(
             title="Issue 1",
             html_url="https://github.com/user/repo/issues/1",
+            author="alice",
             state="open",
             comments=1,
             created_at="2023-01-01T00:00:00Z",
@@ -244,6 +247,7 @@ class TestGetPerIssueMetrics(unittest.TestCase):
         mock_issue2 = MagicMock(
             title="Issue 2",
             html_url="https://github.com/user/repo/issues/2",
+            author="bob",
             state="closed",
             comments=1,
             created_at="2023-01-01T00:00:00Z",
@@ -276,6 +280,7 @@ class TestGetPerIssueMetrics(unittest.TestCase):
             IssueWithMetrics(
                 "Issue 1",
                 "https://github.com/user/repo/issues/1",
+                "alice",
                 timedelta(days=1),
                 None,
                 None,
@@ -284,6 +289,7 @@ class TestGetPerIssueMetrics(unittest.TestCase):
             IssueWithMetrics(
                 "Issue 2",
                 "https://github.com/user/repo/issues/2",
+                "bob",
                 timedelta(days=2),
                 timedelta(days=3),
                 None,
@@ -320,6 +326,9 @@ class TestDiscussionMetrics(unittest.TestCase):
         self.issue1 = {
             "title": "Issue 1",
             "url": "github.com/user/repo/issues/1",
+            "user": {
+                "login": "alice",
+            },
             "createdAt": "2023-01-01T00:00:00Z",
             "comments": {
                 "nodes": [
@@ -335,6 +344,9 @@ class TestDiscussionMetrics(unittest.TestCase):
         self.issue2 = {
             "title": "Issue 2",
             "url": "github.com/user/repo/issues/2",
+            "user": {
+                "login": "bob",
+            },
             "createdAt": "2023-01-01T00:00:00Z",
             "comments": {"nodes": [{"createdAt": "2023-01-03T00:00:00Z"}]},
             "answerChosenAt": "2023-01-05T00:00:00Z",

--- a/test_json_writer.py
+++ b/test_json_writer.py
@@ -16,6 +16,7 @@ class TestWriteToJson(unittest.TestCase):
             IssueWithMetrics(
                 title="Issue 1",
                 html_url="https://github.com/owner/repo/issues/1",
+                author="alice",
                 time_to_first_response=timedelta(days=3),
                 time_to_close=timedelta(days=6),
                 time_to_answer=None,
@@ -26,6 +27,7 @@ class TestWriteToJson(unittest.TestCase):
             IssueWithMetrics(
                 title="Issue 2",
                 html_url="https://github.com/owner/repo/issues/2",
+                author="bob",
                 time_to_first_response=timedelta(days=2),
                 time_to_close=timedelta(days=4),
                 time_to_answer=timedelta(days=1),
@@ -50,6 +52,7 @@ class TestWriteToJson(unittest.TestCase):
                 {
                     "title": "Issue 1",
                     "html_url": "https://github.com/owner/repo/issues/1",
+                    "author": "alice",
                     "time_to_first_response": "3 days, 0:00:00",
                     "time_to_close": "6 days, 0:00:00",
                     "time_to_answer": "None",
@@ -58,6 +61,7 @@ class TestWriteToJson(unittest.TestCase):
                 {
                     "title": "Issue 2",
                     "html_url": "https://github.com/owner/repo/issues/2",
+                    "author": "bob",
                     "time_to_first_response": "2 days, 0:00:00",
                     "time_to_close": "4 days, 0:00:00",
                     "time_to_answer": "1 day, 0:00:00",

--- a/test_labels.py
+++ b/test_labels.py
@@ -75,7 +75,7 @@ class TestGetAverageTimeInLabels(unittest.TestCase):
         self.issues_with_metrics = MagicMock()
         self.issues_with_metrics = [
             IssueWithMetrics(
-                "issue1", "url1", None, None, None, {"bug": timedelta(days=2)}
+                "issue1", "url1", "alice", None, None, None, {"bug": timedelta(days=2)}
             ),
         ]
 

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -32,6 +32,7 @@ class TestWriteToMarkdown(unittest.TestCase):
             IssueWithMetrics(
                 "Issue 1",
                 "https://github.com/user/repo/issues/1",
+                "alice",
                 timedelta(days=1),
                 timedelta(days=2),
                 timedelta(days=3),
@@ -40,6 +41,7 @@ class TestWriteToMarkdown(unittest.TestCase):
             IssueWithMetrics(
                 "Issue 2\r",
                 "https://github.com/user/repo/issues/2",
+                "bob",
                 timedelta(days=3),
                 timedelta(days=4),
                 timedelta(days=5),
@@ -80,12 +82,12 @@ class TestWriteToMarkdown(unittest.TestCase):
             "| Number of items that remain open | 2 |\n"
             "| Number of items closed | 1 |\n"
             "| Total number of items created | 2 |\n\n"
-            "| Title | URL | Time to first response | Time to close |"
+            "| Title | URL | Author | Time to first response | Time to close |"
             " Time to answer | Time spent in bug |\n"
-            "| --- | --- | --- | --- | --- | --- |\n"
-            "| Issue 1 | https://github.com/user/repo/issues/1 | 1 day, 0:00:00 | "
+            "| --- | --- | --- | --- | --- | --- | --- |\n"
+            "| Issue 1 | https://github.com/user/repo/issues/1 | alice | 1 day, 0:00:00 | "
             "2 days, 0:00:00 | 3 days, 0:00:00 | 1 day, 0:00:00 |\n"
-            "| Issue 2 | https://github.com/user/repo/issues/2 | 3 days, 0:00:00 | "
+            "| Issue 2 | https://github.com/user/repo/issues/2 | bob | 3 days, 0:00:00 | "
             "4 days, 0:00:00 | 5 days, 0:00:00 | 2 days, 0:00:00 |\n\n"
             "_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_\n"
             "Search query used to find these items: `is:issue is:open label:bug`\n"
@@ -107,6 +109,7 @@ class TestWriteToMarkdown(unittest.TestCase):
             IssueWithMetrics(
                 "Issue 1",
                 "https://github.com/user/repo/issues/1",
+                "alice",
                 timedelta(days=1),
                 timedelta(days=2),
                 timedelta(days=3),
@@ -115,6 +118,7 @@ class TestWriteToMarkdown(unittest.TestCase):
             IssueWithMetrics(
                 "feat| Issue 2",  # title contains a vertical bar
                 "https://github.com/user/repo/issues/2",
+                "bob",
                 timedelta(days=3),
                 timedelta(days=4),
                 timedelta(days=5),
@@ -154,12 +158,12 @@ class TestWriteToMarkdown(unittest.TestCase):
             "| Number of items that remain open | 2 |\n"
             "| Number of items closed | 1 |\n"
             "| Total number of items created | 2 |\n\n"
-            "| Title | URL | Time to first response | Time to close |"
+            "| Title | URL | Author | Time to first response | Time to close |"
             " Time to answer | Time spent in bug |\n"
-            "| --- | --- | --- | --- | --- | --- |\n"
-            "| Issue 1 | https://github.com/user/repo/issues/1 | 1 day, 0:00:00 | "
+            "| --- | --- | --- | --- | --- | --- | --- |\n"
+            "| Issue 1 | https://github.com/user/repo/issues/1 | alice | 1 day, 0:00:00 | "
             "2 days, 0:00:00 | 3 days, 0:00:00 | 1 day, 0:00:00 |\n"
-            "| feat&#124; Issue 2 | https://github.com/user/repo/issues/2 | 3 days, 0:00:00 | "
+            "| feat&#124; Issue 2 | https://github.com/user/repo/issues/2 | bob | 3 days, 0:00:00 | "
             "4 days, 0:00:00 | 5 days, 0:00:00 | 2 days, 0:00:00 |\n\n"
             "_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_\n"
         )

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -212,6 +212,7 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
             IssueWithMetrics(
                 title="Issue 1",
                 html_url="https://github.com/user/repo/issues/1",
+                author="alice",
                 time_to_first_response=timedelta(minutes=10),
                 time_to_close=timedelta(days=1),
                 time_to_answer=timedelta(hours=2),
@@ -222,6 +223,7 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
             IssueWithMetrics(
                 title="Issue 2",
                 html_url="https://github.com/user/repo/issues/2",
+                author="bob",
                 time_to_first_response=timedelta(minutes=20),
                 time_to_close=timedelta(days=2),
                 time_to_answer=timedelta(hours=4),
@@ -262,10 +264,10 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
             "| Number of items that remain open | 2 |\n"
             "| Number of items closed | 1 |\n"
             "| Total number of items created | 2 |\n\n"
-            "| Title | URL |\n"
-            "| --- | --- |\n"
-            "| Issue 1 | https://github.com/user/repo/issues/1 |\n"
-            "| Issue 2 | https://github.com/user/repo/issues/2 |\n\n"
+            "| Title | URL | Author |\n"
+            "| --- | --- | --- |\n"
+            "| Issue 1 | https://github.com/user/repo/issues/1 | alice |\n"
+            "| Issue 2 | https://github.com/user/repo/issues/2 | bob |\n\n"
             "_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_\n"
             "Search query used to find these items: `repo:user/repo is:issue`\n"
         )

--- a/test_time_to_answer.py
+++ b/test_time_to_answer.py
@@ -35,8 +35,8 @@ class TestGetAverageTimeToAnswer(unittest.TestCase):
         """
         # Arrange
         issues_with_metrics = [
-            IssueWithMetrics("issue1", None),
-            IssueWithMetrics("issue2", None),
+            IssueWithMetrics("issue1", None, None),
+            IssueWithMetrics("issue2", None, None),
         ]
 
         # Act
@@ -53,9 +53,9 @@ class TestGetAverageTimeToAnswer(unittest.TestCase):
 
         # Arrange
         issues_with_metrics = [
-            IssueWithMetrics("issue1", "url1", None, None, timedelta(seconds=10)),
-            IssueWithMetrics("issue2", "url2", None, None, timedelta(seconds=20)),
-            IssueWithMetrics("issue3", "url3", None, None, timedelta(seconds=30)),
+            IssueWithMetrics("issue1", "url1", "alice", None, None, timedelta(seconds=10)),
+            IssueWithMetrics("issue2", "url2", "bob", None, None, timedelta(seconds=20)),
+            IssueWithMetrics("issue3", "url3", "carol", None, None, timedelta(seconds=30)),
         ]
 
         # Act

--- a/test_time_to_close.py
+++ b/test_time_to_close.py
@@ -27,17 +27,19 @@ class TestGetAverageTimeToClose(unittest.TestCase):
             IssueWithMetrics(
                 "Issue 1",
                 "https://github.com/user/repo/issues/1",
+                "alice",
                 None,
                 timedelta(days=2),
             ),
             IssueWithMetrics(
                 "Issue 2",
                 "https://github.com/user/repo/issues/2",
+                "bob",
                 None,
                 timedelta(days=4),
             ),
             IssueWithMetrics(
-                "Issue 3", "https://github.com/user/repo/issues/3", None, None
+                "Issue 3", "https://github.com/user/repo/issues/3", "carol", None, None
             ),
         ]
 
@@ -51,13 +53,13 @@ class TestGetAverageTimeToClose(unittest.TestCase):
         # Create mock data
         issues_with_metrics = [
             IssueWithMetrics(
-                "Issue 1", "https://github.com/user/repo/issues/1", None, None
+                "Issue 1", "https://github.com/user/repo/issues/1", "alice", None, None
             ),
             IssueWithMetrics(
-                "Issue 2", "https://github.com/user/repo/issues/2", None, None
+                "Issue 2", "https://github.com/user/repo/issues/2", "bob", None, None
             ),
             IssueWithMetrics(
-                "Issue 3", "https://github.com/user/repo/issues/3", None, None
+                "Issue 3", "https://github.com/user/repo/issues/3", "carol", None, None
             ),
         ]
 

--- a/test_time_to_first_response.py
+++ b/test_time_to_first_response.py
@@ -325,12 +325,12 @@ class TestGetAverageTimeToFirstResponse(unittest.TestCase):
         # Create mock data
         issues_with_metrics = [
             IssueWithMetrics(
-                "Issue 1", "https://github.com/user/repo/issues/1", timedelta(days=1)
+                "Issue 1", "https://github.com/user/repo/issues/1", "alice", timedelta(days=1)
             ),
             IssueWithMetrics(
-                "Issue 2", "https://github.com/user/repo/issues/2", timedelta(days=2)
+                "Issue 2", "https://github.com/user/repo/issues/2", "bob", timedelta(days=2)
             ),
-            IssueWithMetrics("Issue 3", "https://github.com/user/repo/issues/3", None),
+            IssueWithMetrics("Issue 3", "https://github.com/user/repo/issues/3", "carol", None),
         ]
 
         # Call the function and check the result
@@ -343,8 +343,8 @@ class TestGetAverageTimeToFirstResponse(unittest.TestCase):
 
         # Create mock data with all None
         issues_with_metrics = [
-            IssueWithMetrics("Issue 1", "https://github.com/user/repo/issues/1", None),
-            IssueWithMetrics("Issue 2", "https://github.com/user/repo/issues/2", None),
+            IssueWithMetrics("Issue 1", "https://github.com/user/repo/issues/1", "alice", None),
+            IssueWithMetrics("Issue 2", "https://github.com/user/repo/issues/2", "bob", None),
         ]
 
         # Call the function and check the result


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
close #128 

<!-- Describe what the changes are -->

## Proposed Changes

I have added an author column to each issue. As seen in the original issue and this simple sample, it now displays the user who created the issue. In the original issue, there is an `@`, but I decided not to include it as it could potentially trigger numerous notifications due to mentions.

```markdown
| Title | URL | Author | Time to first response | Time to close | Time to answer | Time spent in waiting-for-review | Time spent in waiting-for-manager |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Monthly issue metrics report | https://github.com/Okabe-Junya/sandbox/issues/249 | github-actions[bot] | None | None | None | None | None |
```

## Readiness Checklist

- The attributes of the IssueWithMetrics class have been modified. Therefore, this PR involves somewhat extensive changes.
- Obtaining the author of the discussion was challenging, so it is not included in this PR (it is set to None).
- The author attributes are mandatory, not optional. Would it be better if they were optional??
- For the sample users in the tests, I am using alice, bob, and carol; is this appropriate?

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
