### PR TITLE
[docs] Add back references to footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The issues/pull requests/discussions to search for can be filtered by using a se
 
 | Metric | Description |
 |--------|-------------|
-|Time to First Response | The duration from creation to the initial comment or review.|
-|Time to Close | The period from creation to closure.|
+|Time to First Response | The duration from creation to the initial comment or review.*|
+|Time to Close | The period from creation to closure.*|
 |Time to Answer (Discussions Only) | The time from creation to an answer.|
 |Time in Label | The duration from label application to removal, requires `LABELS_TO_MEASURE` env variable.|
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The issues/pull requests/discussions to search for can be filtered by using a se
 
 *For pull requests, these metrics exclude the time the PR was in draft mode.
 
-*For issues and pull requests, issue/pull request author's own comments and comments by bots are excluded.
+*For issues and pull requests, comments by issue/pull request author's and comments by bots are excluded.
 
 This action, developed by GitHub OSPO for our internal use, is open-sourced for your potential benefit.
 Feel free to inquire about its usage by creating an issue in this repository.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The issues/pull requests/discussions to search for can be filtered by using a se
 
 *For pull requests, these metrics exclude the time the PR was in draft mode.
 
-*For Issue and pull requests, issue/pull request author's own comments and comments by bots are excluded.
+*For issues and pull requests, issue/pull request author's own comments and comments by bots are excluded.
 
 This action, developed by GitHub OSPO for our internal use, is open-sourced for your potential benefit.
 Feel free to inquire about its usage by creating an issue in this repository.


### PR DESCRIPTION
In #139 the references to the footnotes were accidentally removed.

## Proposed Changes

I added back in the references to the footnotes in the top-most table that explains the different metrics.
Also suggested some rewording for better readability.


## Readiness Checklist

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request
- [X] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer
- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
