### PR TITLE
docs: add `Getting Started` section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,57 @@ Feel free to inquire about its usage by creating an issue in this repository.
 To find syntax for search queries, check out the [documentation on searching issues and pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests)
 or the [documentation on searching discussions](https://docs.github.com/en/search-github/searching-on-github/searching-discussions).
 
+## Quick Start
+
+Create a workflow file (ie. `.github/workflows/issue-metrics.yml`) in your repository with the following contents:
+
+**Note**: `repo:owner/repo` is the repository you want to measure metrics on
+
+```yaml
+
+```yaml
+name: Monthly issue metrics
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '3 2 1 * *'
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  build:
+    name: issue metrics
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get dates for last month
+      shell: bash
+      run: |
+        # Calculate the first day of the previous month
+        first_day=$(date -d "last month" +%Y-%m-01)
+
+        # Calculate the last day of the previous month
+        last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
+
+        #Set an environment variable with the date range
+        echo "$first_day..$last_day"
+        echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
+
+    - name: Run issue-metrics tool
+      uses: github/issue-metrics@v2
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:owner/repo is:issue created:${{ env.last_month }} -reason:"not planned"'
+
+    - name: Create issue
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: Monthly issue metrics report
+        token: ${{ secrets.GITHUB_TOKEN }}
+        content-filepath: ./issue_metrics.md
+```
+
 ## Example use cases
 
 - As a maintainer, I want to see metrics for issues and pull requests on the repository I maintain in order to ensure I am giving them the proper amount of attention.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Feel free to inquire about its usage by creating an issue in this repository.
 To find syntax for search queries, check out the [documentation on searching issues and pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests)
 or the [documentation on searching discussions](https://docs.github.com/en/search-github/searching-on-github/searching-discussions).
 
-## Quick Start
+## Getting Started
 
 Create a workflow file (ie. `.github/workflows/issue-metrics.yml`) in your repository with the following contents:
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
close #142 

<!-- Describe what the changes are -->

## Proposed Changes

- add `Getting Started` section in README

## Readiness Checklist

Is the term `Quick Start` really appropriate? There are similar expressions like:

- `Getting Started`
- `Usage`
- `Tutorial`
- `Simple Example/Basic Example`
- ...

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer
- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
