### PR TITLE
refactor(get_env_vars): use get_env_vars() for consistent env variable retrieval

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,93 @@
+"""A module for managing environment variables used in GitHub metrics calculation.
+
+This module defines a class for encapsulating environment variables and a function to retrieve these variables.
+
+Classes:
+    EnvVars: Represents the collection of environment variables used in the script.
+
+Functions:
+    get_env_vars: Retrieves and returns an instance of EnvVars populated with environment variables.
+"""
+import os
+from typing import List
+
+
+class EnvVars:
+    # pylint: disable=too-many-instance-attributes
+    """
+    Environment variables
+
+    Attributes:
+        search_query (str): Search query used to filter issues/prs/discussions on GitHub
+        gh_token (str): GitHub personal access token (PAT) for API authentication
+        labels_to_measure (List[str]): List of labels to measure how much time the lable is applied
+        ignore_users (List[str]): List of usernames to ignore when calculating metrics
+        github_server_url (str): URL of GitHub server (Github.com or Github Enterprise)
+        hide_author (str): If set, the author's information is hidden in the output
+        hide_time_to_first_response (str): If set, the time to first response metric is hidden in the output
+        hide_time_to_close (str): If set, the time to close metric is hidden in the output
+        hide_time_to_answer (str): If set, the time to answer discussions is hidden in the output
+        hide_label_metrics (str): If set, the label metrics are hidden in the output
+    """
+    def __init__(self, search_query: str, gh_token: str, labels_to_measure: List[str], ignore_user: List[str],
+                 github_server_url: str, hide_author: str, hide_time_to_first_response: str,
+                 hide_time_to_close: str, hide_time_to_answer: str, hide_label_metrics: str):
+        self.search_query = search_query
+        self.gh_token = gh_token
+        self.labels_to_measure = labels_to_measure
+        self.ignore_users = ignore_user
+        self.github_server_url = github_server_url
+        self.hide_author = hide_author
+        self.hide_time_to_first_response = hide_time_to_first_response
+        self.hide_time_to_close = hide_time_to_close
+        self.hide_time_to_answer = hide_time_to_answer
+        self.hide_label_metrics = hide_label_metrics
+
+
+def get_env_vars() -> EnvVars:
+    """
+    Get the environment variables for use in the script.
+
+    Returns EnvVars object with all environment variables
+    """
+    search_query = os.getenv("SEARCH_QUERY")
+    if not search_query:
+        raise ValueError("SEARCH_QUERY environment variable not set")
+
+    gh_token = os.getenv("GH_TOKEN")
+    if not gh_token:
+        raise ValueError("GITHUB_TOKEN environment variable not set")
+
+    labels_to_measure = os.getenv("LABELS_TO_MEASURE")
+    if labels_to_measure:
+        labels_to_measure = labels_to_measure.split(",")
+    else:
+        labels_to_measure = []
+
+    ignore_users = os.getenv("IGNORE_USERS")
+    if ignore_users:
+        ignore_users = ignore_users.split(",")
+    else:
+        ignore_users = []
+
+    github_server_url = os.getenv("GITHUB_SERVER_URL")
+
+    # Hidden columns
+    hide_author = os.getenv("HIDE_AUTHOR")
+    hide_time_to_first_response = os.getenv("HIDE_TIME_TO_FIRST_RESPONSE")
+    hide_time_to_close = os.getenv("HIDE_TIME_TO_CLOSE")
+    hide_time_to_answer = os.getenv("HIDE_TIME_TO_ANSWER")
+    hide_label_metrics = os.getenv("HIDE_LABEL_METRICS")
+
+    return EnvVars(
+        search_query,
+        gh_token,
+        labels_to_measure,
+        ignore_users,
+        github_server_url,
+        hide_author,
+        hide_time_to_first_response,
+        hide_time_to_close,
+        hide_time_to_answer,
+        hide_label_metrics
+    )

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -24,11 +24,11 @@ Functions:
         Get the columns that are not hidden.
 """
 
-import os
 from datetime import timedelta
 from typing import List, Union
 
 from classes import IssueWithMetrics
+from config import get_env_vars
 
 
 def get_non_hidden_columns(labels) -> List[str]:
@@ -43,24 +43,27 @@ def get_non_hidden_columns(labels) -> List[str]:
 
     """
     columns = ["Title", "URL"]
+
+    env_vars = get_env_vars()
+
     # Find the number of columns and which are to be hidden
-    hide_author = os.getenv("HIDE_AUTHOR")
+    hide_author = env_vars.hide_author
     if not hide_author:
         columns.append("Author")
 
-    hide_time_to_first_response = os.getenv("HIDE_TIME_TO_FIRST_RESPONSE")
+    hide_time_to_first_response = env_vars.hide_time_to_first_response
     if not hide_time_to_first_response:
         columns.append("Time to first response")
 
-    hide_time_to_close = os.getenv("HIDE_TIME_TO_CLOSE")
+    hide_time_to_close = env_vars.hide_time_to_close
     if not hide_time_to_close:
         columns.append("Time to close")
 
-    hide_time_to_answer = os.getenv("HIDE_TIME_TO_ANSWER")
+    hide_time_to_answer = env_vars.hide_time_to_answer
     if not hide_time_to_answer:
         columns.append("Time to answer")
 
-    hide_label_metrics = os.getenv("HIDE_LABEL_METRICS")
+    hide_label_metrics = env_vars.hide_label_metrics
     if not hide_label_metrics and labels:
         for label in labels:
             columns.append(f"Time spent in {label}")

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -15,6 +15,13 @@ from classes import IssueWithMetrics
 from markdown_writer import write_to_markdown
 
 
+@patch.dict(
+    os.environ,
+    {
+        "SEARCH_QUERY": "is:open repo:user/repo",
+        "GH_TOKEN": "test_token"
+    },
+)
 class TestWriteToMarkdown(unittest.TestCase):
     """Test the write_to_markdown function."""
 
@@ -234,22 +241,19 @@ class TestWriteToMarkdown(unittest.TestCase):
         )
 
 
+@patch.dict(
+    os.environ,
+    {
+        "SEARCH_QUERY": "is:open repo:user/repo",
+        "GH_TOKEN": "test_token",
+        "HIDE_TIME_TO_FIRST_RESPONSE": "True",
+        "HIDE_TIME_TO_CLOSE": "True",
+        "HIDE_TIME_TO_ANSWER": "True",
+        "HIDE_LABEL_METRICS": "True"
+    },
+)
 class TestWriteToMarkdownWithEnv(unittest.TestCase):
     """Test the write_to_markdown function with the HIDE* environment variables set."""
-
-    def setUp(self):
-        # Set the HIDE* environment variables to True
-        os.environ["HIDE_TIME_TO_FIRST_RESPONSE"] = "True"
-        os.environ["HIDE_TIME_TO_CLOSE"] = "True"
-        os.environ["HIDE_TIME_TO_ANSWER"] = "True"
-        os.environ["HIDE_LABEL_METRICS"] = "True"
-
-    def tearDown(self):
-        # Unset the HIDE* environment variables
-        os.environ.pop("HIDE_TIME_TO_FIRST_RESPONSE")
-        os.environ.pop("HIDE_TIME_TO_CLOSE")
-        os.environ.pop("HIDE_TIME_TO_ANSWER")
-        os.environ.pop("HIDE_LABEL_METRICS")
 
     def test_writes_markdown_file_with_non_hidden_columns_only(self):
         """


### PR DESCRIPTION
Refactor Environment Variable Retrieval Across Application - Resolves #168

## Overview

This PR addresses issue #168 by refactoring the application to consistently use the `get_env_vars()` function for environment variable retrieval. 

## Proposed Changes


- Added a new module in `config.py`, introducing the following components:
  - `EnvVars`: A class that encapsulates all environment variables required in the script.
  - `get_env_vars()`: A function to retrieve an instance of `EnvVars` populated with environment variables.
  
## Readiness Checklist

### Author/Contributor
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer
- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
