### PR TITLE
Handle Pending Review Case

### DIFF
--- a/most_active_mentors.py
+++ b/most_active_mentors.py
@@ -147,6 +147,8 @@ def ignore_comment(
         or comment_user.type == "Bot"
         # ignore comments by the issue creator
         or comment_user.login == issue_user.login
+        # ignore pending reviews
+        or not comment_created_at
         # ignore comments created before the issue was ready for review
         or (ready_for_review_at and comment_created_at < ready_for_review_at)
     )

--- a/test_time_to_first_response.py
+++ b/test_time_to_first_response.py
@@ -232,6 +232,39 @@ class TestMeasureTimeToFirstResponse(unittest.TestCase):
 
         # Check the results
         self.assertEqual(result, expected_result)
+        
+    def test_measure_time_to_first_response_ignore_pending_review(self):
+        """Test that measure_time_to_first_response ignores pending reviews """
+        
+        
+        mock_issue1 = MagicMock()
+        mock_issue1.comments = 2
+        mock_issue1.issue.user.login = "issue_owner"
+        mock_issue1.created_at = "2023-01-01T00:00:00Z"
+        
+        # Set up the mock GitHub pull request comments (one ignored, one not ignored)
+        # Pending Review
+        mock_pr_comment1 = MagicMock()
+        mock_pr_comment1.submitted_at = None
+        # Submitted Comment
+        mock_pr_comment2 = MagicMock()
+        mock_pr_comment2.submitted_at = datetime.fromisoformat(
+            "2023-01-04T00:00:00Z"
+        )
+       
+        mock_pull_request = MagicMock()
+        mock_pull_request.reviews.return_value = [mock_pr_comment1, mock_pr_comment2]
+
+        ready_for_review_at = datetime.fromisoformat("2023-01-03T00:00:00Z")
+
+        # Call the function
+        result = measure_time_to_first_response(
+            mock_issue1, None, mock_pull_request, ready_for_review_at
+        )
+        expected_result = timedelta(days=1)
+
+        # Check the results
+        self.assertEqual(result, expected_result)
 
     def test_measure_time_to_first_response_only_ignored_users(self):
         """Test that measure_time_to_first_response returns empty for an issue with only ignored users."""

--- a/test_time_to_first_response.py
+++ b/test_time_to_first_response.py
@@ -232,26 +232,23 @@ class TestMeasureTimeToFirstResponse(unittest.TestCase):
 
         # Check the results
         self.assertEqual(result, expected_result)
-        
+
     def test_measure_time_to_first_response_ignore_pending_review(self):
-        """Test that measure_time_to_first_response ignores pending reviews """
-        
-        
+        """Test that measure_time_to_first_response ignores pending reviews"""
+
         mock_issue1 = MagicMock()
         mock_issue1.comments = 2
         mock_issue1.issue.user.login = "issue_owner"
         mock_issue1.created_at = "2023-01-01T00:00:00Z"
-        
+
         # Set up the mock GitHub pull request comments (one ignored, one not ignored)
         # Pending Review
         mock_pr_comment1 = MagicMock()
         mock_pr_comment1.submitted_at = None
         # Submitted Comment
         mock_pr_comment2 = MagicMock()
-        mock_pr_comment2.submitted_at = datetime.fromisoformat(
-            "2023-01-04T00:00:00Z"
-        )
-       
+        mock_pr_comment2.submitted_at = datetime.fromisoformat("2023-01-04T00:00:00Z")
+
         mock_pull_request = MagicMock()
         mock_pull_request.reviews.return_value = [mock_pr_comment1, mock_pr_comment2]
 

--- a/time_to_first_response.py
+++ b/time_to_first_response.py
@@ -129,7 +129,7 @@ def ignore_comment(
     user_is_a_bot: bool = str(comment_user.type.lower()) == "bot"
     user_is_issue_creator: bool = str(comment_user.login) == str(issue_user.login)
     issue_was_created_before_ready_for_review: bool = False
-    is_pending_comment: bool = not isinstance(comment_created_at,datetime)
+    is_pending_comment: bool = not isinstance(comment_created_at, datetime)
     if ready_for_review_at and not is_pending_comment:
         issue_was_created_before_ready_for_review = (
             comment_created_at < ready_for_review_at

--- a/time_to_first_response.py
+++ b/time_to_first_response.py
@@ -129,7 +129,8 @@ def ignore_comment(
     user_is_a_bot: bool = str(comment_user.type.lower()) == "bot"
     user_is_issue_creator: bool = str(comment_user.login) == str(issue_user.login)
     issue_was_created_before_ready_for_review: bool = False
-    if ready_for_review_at:
+    is_pending_comment: bool = not bool(comment_created_at)
+    if ready_for_review_at and not is_pending_comment:
         issue_was_created_before_ready_for_review = (
             comment_created_at < ready_for_review_at
         )
@@ -137,6 +138,7 @@ def ignore_comment(
         user_is_ignored
         or user_is_a_bot
         or user_is_issue_creator
+        or is_pending_comment
         or issue_was_created_before_ready_for_review
     )
     return result

--- a/time_to_first_response.py
+++ b/time_to_first_response.py
@@ -129,7 +129,7 @@ def ignore_comment(
     user_is_a_bot: bool = str(comment_user.type.lower()) == "bot"
     user_is_issue_creator: bool = str(comment_user.login) == str(issue_user.login)
     issue_was_created_before_ready_for_review: bool = False
-    is_pending_comment: bool = not bool(comment_created_at)
+    is_pending_comment: bool = not isinstance(comment_created_at,datetime)
     if ready_for_review_at and not is_pending_comment:
         issue_was_created_before_ready_for_review = (
             comment_created_at < ready_for_review_at


### PR DESCRIPTION
## Proposed Changes
Check that `comment_created_at` is valid datetime.

`comment_created_at` might not exist if reviews were still pending when PR was merged. This would cause a TypeError in future comparisons: Issue #173. 

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
