### PR TITLE
fix: release container image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@
       steps:
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3
+          with:
+            driver-opts: |
+              image=moby/buildkit:v0.13.1
         - name: Log in to the Container registry
           uses: docker/login-action@v3
           with:


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Seems the [`Unexpected status from HEAD request to <url>: 400 Bad Request`](https://github.com/github/issue-metrics/actions/runs/8758107284/job/24038180863#step:5:1024) is an intermittent error in GitHub Actions and pushing to ghcr that can be solved by using moby/buildkit via
https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381

Going to try this with latest release of moby/buildkit to see if it fixes it

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
