### PR TITLE
fix: use GitHub App token when authed with GitHub App

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ examples: "feat: add new logger" or "fix: remove unused imports"
 
 ### Reviewer
 
-- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
+- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,63 @@
+"""
+This is the module that contains functions related to authenticating
+to GitHub.
+"""
+
+import github3
+import requests
+
+
+def auth_to_github(
+    gh_app_id: str,
+    gh_app_installation_id: int,
+    gh_app_private_key_bytes: bytes,
+    token: str,
+    ghe: str,
+) -> github3.GitHub:
+    """
+    Connect to GitHub.com or GitHub Enterprise, depending on env variables.
+
+    Returns:
+        github3.GitHub: A github api connection.
+    """
+
+    if gh_app_id and gh_app_private_key_bytes and gh_app_installation_id:
+        gh = github3.github.GitHub()
+        gh.login_as_app_installation(
+            gh_app_private_key_bytes, gh_app_id, gh_app_installation_id
+        )
+        github_connection = gh
+    elif ghe and token:
+        github_connection = github3.github.GitHubEnterprise(ghe, token=token)
+    elif token:
+        github_connection = github3.login(token=token)
+    else:
+        raise ValueError(
+            "GH_TOKEN or the set of [GH_APP_ID, GH_APP_INSTALLATION_ID, GH_APP_PRIVATE_KEY] environment variables are not set"
+        )
+
+    return github_connection  # type: ignore
+
+
+def get_github_app_installation_token(
+    gh_app_id: str, gh_app_private_key_bytes: bytes, gh_app_installation_id: str
+) -> str | None:
+    """
+    Get a GitHub App Installation token.
+    Args:
+        gh_app_id (str): the GitHub App ID
+        gh_app_private_key_bytes (bytes): the GitHub App Private Key
+        gh_app_installation_id (str): the GitHub App Installation ID
+    Returns:
+        str: the GitHub App token
+    """
+    jwt_headers = github3.apps.create_jwt_headers(gh_app_private_key_bytes, gh_app_id)
+    url = f"https://api.github.com/app/installations/{gh_app_installation_id}/access_tokens"
+
+    try:
+        response = requests.post(url, headers=jwt_headers, json=None, timeout=5)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"Request failed: {e}")
+        return None
+    return response.json().get("token")

--- a/most_active_mentors.py
+++ b/most_active_mentors.py
@@ -56,8 +56,8 @@ def count_comments_per_user(
     Args:
         issue (Union[github3.issues.Issue, None]): A GitHub issue.
         pull_request (Union[github3.pulls.PullRequest, None]): A GitHub pull
-        request.  ignore_users (List[str]): A list of GitHub usernames to
-        ignore.
+        request.
+        ignore_users (List[str]): A list of GitHub usernames to ignore.
         max_comments_to_eval: Maximum number of comments per item to look at.
         heavily_involved: Maximum number of comments to count for one
         user per issue.

--- a/test_auth.py
+++ b/test_auth.py
@@ -1,0 +1,72 @@
+"""A module containing unit tests for the auth module.
+
+This module contains unit tests for the functions in the auth module
+that authenticate to github.
+
+Classes:
+    TestAuthToGithub: A class to test the auth_to_github function.
+
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import github3
+from auth import auth_to_github, get_github_app_installation_token
+
+
+class TestAuthToGithub(unittest.TestCase):
+    """Test the auth_to_github function."""
+
+    @patch("github3.github.GitHub.login_as_app_installation")
+    def test_auth_to_github_with_github_app(self, mock_login):
+        """
+        Test the auth_to_github function when GitHub app
+        parameters provided.
+        """
+        mock_login.return_value = MagicMock()
+        result = auth_to_github(12345, 678910, b"hello", "", "")
+
+        self.assertIsInstance(result, github3.github.GitHub)
+
+    def test_auth_to_github_with_token(self):
+        """
+        Test the auth_to_github function when the token is provided.
+        """
+        result = auth_to_github(None, None, b"", "token", "")
+
+        self.assertIsInstance(result, github3.github.GitHub)
+
+    def test_auth_to_github_without_authentication_information(self):
+        """
+        Test the auth_to_github function when authentication information is not provided.
+        Expect a ValueError to be raised.
+        """
+        with self.assertRaises(ValueError):
+            auth_to_github(None, None, b"", "", "")
+
+    def test_auth_to_github_with_ghe(self):
+        """
+        Test the auth_to_github function when the GitHub Enterprise URL is provided.
+        """
+        result = auth_to_github(None, None, b"", "token", "https://github.example.com")
+
+        self.assertIsInstance(result, github3.github.GitHubEnterprise)
+
+    @patch("github3.apps.create_jwt_headers", MagicMock(return_value="gh_token"))
+    @patch("requests.post")
+    def test_get_github_app_installation_token(self, mock_post):
+        """
+        Test the get_github_app_installation_token function.
+        """
+        dummy_token = "dummytoken"
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"token": dummy_token}
+        mock_post.return_value = mock_response
+
+        result = get_github_app_installation_token(
+            b"gh_private_token", "gh_app_id", "gh_installation_id"
+        )
+
+        self.assertEqual(result, dummy_token)

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -6,7 +6,6 @@ issues and comments to test the functions' behavior.
 
 Classes:
     TestSearchIssues: A class to test the search_issues function.
-    TestAuthToGithub: A class to test the auth_to_github function.
     TestGetPerIssueMetrics: A class to test the get_per_issue_metrics function.
     TestGetEnvVars: A class to test the get_env_vars function.
     TestMain: A class to test the main function.
@@ -18,11 +17,9 @@ import unittest
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
-import github3
 import issue_metrics
 from issue_metrics import (
     IssueWithMetrics,
-    auth_to_github,
     get_env_vars,
     get_owner_and_repository,
     get_per_issue_metrics,
@@ -92,45 +89,6 @@ class TestGetOwnerAndRepository(unittest.TestCase):
         result = get_owner_and_repository("is:blah")
         self.assertIsNone(result.get("owner"))
         self.assertIsNone(result.get("repository"))
-
-
-class TestAuthToGithub(unittest.TestCase):
-    """Test the auth_to_github function."""
-
-    @patch("github3.github.GitHub.login_as_app_installation")
-    def test_auth_to_github_with_github_app(self, mock_login):
-        """
-        Test the auth_to_github function when GitHub app
-        parameters provided.
-        """
-        mock_login.return_value = MagicMock()
-        result = auth_to_github(12345, 678910, b"hello", "", "")
-
-        self.assertIsInstance(result, github3.github.GitHub)
-
-    def test_auth_to_github_with_token(self):
-        """
-        Test the auth_to_github function when the token is provided.
-        """
-        result = auth_to_github(None, None, b"", "token", "")
-
-        self.assertIsInstance(result, github3.github.GitHub)
-
-    def test_auth_to_github_without_authentication_information(self):
-        """
-        Test the auth_to_github function when authentication information is not provided.
-        Expect a ValueError to be raised.
-        """
-        with self.assertRaises(ValueError):
-            auth_to_github(None, None, b"", "", "")
-
-    def test_auth_to_github_with_ghe(self):
-        """
-        Test the auth_to_github function when the GitHub Enterprise URL is provided.
-        """
-        result = auth_to_github(None, None, b"", "token", "https://github.example.com")
-
-        self.assertIsInstance(result, github3.github.GitHubEnterprise)
 
 
 class TestGetEnvVars(unittest.TestCase):


### PR DESCRIPTION


# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Currently we are still trying to use the GH_TOKEN env var when making api/graphql calls even after authenticating with a GitHub App Installation. This change fixes that.

Also fixed a few other things while in here:

- [x] split authentication to auth.py file (like other actions)
- [x] fix arguments to the count_comments_per_user function

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
