### PR TITLE
feat: Avoid API Rate-Limiting

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -65,11 +65,24 @@ def search_issues(
         List[github3.search.IssueSearchResult]: A list of issues that match the search query.
     """
 
+    # Rate Limit Handling: API only allows 30 requests per minute
     def wait_for_api_refresh(iterator: github3.structs.SearchIterator):
-        # Rate Limit Handling: API only allows 30 requests per minute
+        max_retries = 5
+        retry_count = 0
+        sleep_time = 70
+
         while iterator.ratelimit_remaining < 5:
-            print("Github API Rate Limit Low, waiting 1 minute to refresh")
-            sleep(65)
+            if retry_count >= max_retries:
+                raise RuntimeError("Exceeded maximum retries for API rate limit")
+
+            print(
+                f"GitHub API Rate Limit Low, waiting {sleep_time} seconds to refresh."
+            )
+            sleep(sleep_time)
+
+            # Exponentially increase the sleep time for the next retry
+            sleep_time *= 2
+            retry_count += 1
 
     issues_per_page = 100
 

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -42,13 +42,20 @@ class TestSearchIssues(unittest.TestCase):
 
     def test_search_issues(self):
         """Test that search_issues returns the correct issues."""
+
         # Set up the mock GitHub connection object
-        mock_connection = MagicMock()
         mock_issues = [
             MagicMock(title="Issue 1"),
             MagicMock(title="Issue 2"),
         ]
-        mock_connection.search_issues.return_value = mock_issues
+
+        # simulating github3.structs.SearchIterator return value
+        mock_search_result = MagicMock()
+        mock_search_result.__iter__.return_value = iter(mock_issues)
+        mock_search_result.ratelimit_remaining = 30
+
+        mock_connection = MagicMock()
+        mock_connection.search_issues.return_value = mock_search_result
 
         # Call search_issues and check that it returns the correct issues
         repo_with_owner = {"owner": "owner1", "repository": "repo1"}


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

Rate limiting of the Github search API is causing a 403 Authentication Error for some users. Issues #217 and potentially #166 are related.

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

The github3 SearchIterator object has a ratelimit_remaining property that is used to measure if we are near API rate limits. If remaining requests are low (<5), there is a 1 minute delay to refresh requests with exponential increases in delays ([corresponding rate limit docs](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit)). This is consistent with Github's recommended [best practice guidelines](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#handle-rate-limit-errors-appropriately) since the github3 wrappers prevent us from easily accessing the retry headers. 


## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
