### PR TITLE
fix: Negative time reported for "time label applied" measurement

### DIFF
--- a/labels.py
+++ b/labels.py
@@ -74,7 +74,7 @@ def get_label_metrics(issue: github3.issues.Issue, labels: List[str]) -> dict:
 
     for label in labels:
         # if the label is still on there, add the time from the last event to now
-        if label in labeled and label not in unlabeled:
+        if label in labeled:
             # if the issue is closed, add the time from the issue creation to the closed_at time
             if issue.state == "closed":
                 label_metrics[label] += datetime.fromisoformat(

--- a/test_labels.py
+++ b/test_labels.py
@@ -51,7 +51,6 @@ class TestLabels(unittest.TestCase):
         self.assertEqual(events[1].label["name"], "bug")
         self.assertEqual(events[2].label["name"], "bug")
 
-
     def test_get_label_metrics_closed_issue(self):
         """Test get_label_metrics using a closed issue"""
         labels = ["bug", "feature"]
@@ -64,8 +63,14 @@ class TestLabels(unittest.TestCase):
         self.issue.state = "open"
         labels = ["bug", "feature"]
         metrics = get_label_metrics(self.issue, labels)
-        self.assertLessEqual(metrics["bug"], datetime.now(pytz.utc) - datetime(2021, 1, 2, tzinfo=pytz.UTC))
-        self.assertGreater(metrics["bug"], datetime.now(pytz.utc) - datetime(2021, 1, 3, tzinfo=pytz.UTC))
+        self.assertLessEqual(
+            metrics["bug"],
+            datetime.now(pytz.utc) - datetime(2021, 1, 2, tzinfo=pytz.UTC),
+        )
+        self.assertGreater(
+            metrics["bug"],
+            datetime.now(pytz.utc) - datetime(2021, 1, 3, tzinfo=pytz.UTC),
+        )
         self.assertLessEqual(
             metrics["feature"],
             datetime.now(pytz.utc) - datetime(2021, 1, 2, tzinfo=pytz.UTC),


### PR DESCRIPTION
# Pull Request

Address case where negative time for "time label applied" is reported for labels that have at some point been both "labeled" and "unlabeled" on a given issue (https://github.com/github/issue-metrics/issues/282)

## Proposed Changes

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
