### PR TITLE
fix: allow access to forked pull request labels for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@
         - closed
       branches:
         - main
+    pull_request_target:
+      types:
+        - closed
+      branches:
+        - main
 
   permissions:
     contents: read


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Release fails if pull request is from a fork currently because we can't access the labels on the forked pull request which helps us determine semver for next release.

Saw this after merging https://github.com/github/issue-metrics/pull/283 (from a fork)

Add pull_request_target to release action workflow

I am not worried about the security implications with us checking out the forked pull requests code.  This action only fires after a merge to main so this means the pull request code has been reviewed by a maintainer.  We are post-CI/code run.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
