### PR TITLE
chore: remove pull_request target if we already have pull_request_target

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -2,11 +2,7 @@
   name: Auto Labeler
 
   on:
-    # pull_request event is required only for autolabeler
-    pull_request:
-      # Only following types are handled by the action, but one can default to all as well
-      types: [opened, reopened, synchronize]
-    # pull_request_target event is required for autolabeler to support PRs from forks
+    # pull_request_target event is required for autolabeler to support all PRs including forks
     pull_request_target:
       types: [opened, reopened, synchronize]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,6 @@
 
   on:
     workflow_dispatch:
-    pull_request:
-      types:
-        - closed
-      branches:
-        - main
     pull_request_target:
       types:
         - closed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issue Metrics Action
 
-[![CodeQL](https://github.com/github/issue-metrics/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/github/issue-metrics/actions/workflows/codeql-analysis.yml)
+[![CodeQL](https://github.com/github/issue-metrics/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/github/issue-metrics/actions/workflows/github-code-scanning/codeql)
 [![Docker Image CI](https://github.com/github/issue-metrics/actions/workflows/docker-image.yml/badge.svg)](https://github.com/github/issue-metrics/actions/workflows/docker-image.yml)
 [![Python package](https://github.com/github/issue-metrics/actions/workflows/python-package.yml/badge.svg)](https://github.com/github/issue-metrics/actions/workflows/python-package.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/github/issue-metrics/badge)](https://scorecard.dev/viewer/?uri=github.com/github/issue-metrics)


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

- [x] auto-labeler action
- [x] release action
- [x] fix codeql bade in README (after we removed custom workflow in https://github.com/github/issue-metrics/pull/276)

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
