### PR TITLE
fix: issue counts incorrect when HIDE_TIME_TO_CLOSE is True

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -193,14 +193,12 @@ def get_per_issue_metrics(
                 )
             if env_vars.hide_time_to_answer is False:
                 issue_with_metrics.time_to_answer = measure_time_to_answer(issue)
-            if env_vars.hide_time_to_close is False:
-                if issue["closedAt"]:
-                    issue_with_metrics.time_to_close = measure_time_to_close(
-                        None, issue
-                    )
-                    num_issues_closed += 1
-                else:
-                    num_issues_open += 1
+            if env_vars.hide_time_to_close is False and issue["closedAt"]:
+                issue_with_metrics.time_to_close = measure_time_to_close(None, issue)
+            if issue["closedAt"]:
+                num_issues_closed += 1
+            else:
+                num_issues_open += 1
         else:
             issue_with_metrics = IssueWithMetrics(
                 issue.title,  # type: ignore
@@ -236,19 +234,19 @@ def get_per_issue_metrics(
                 )
             if labels and env_vars.hide_label_metrics is False:
                 issue_with_metrics.label_metrics = get_label_metrics(issue, labels)
-            if env_vars.hide_time_to_close is False:
-                if issue.state == "closed":  # type: ignore
-                    if pull_request:
-                        issue_with_metrics.time_to_close = measure_time_to_merge(
-                            pull_request, ready_for_review_at
-                        )
-                    else:
-                        issue_with_metrics.time_to_close = measure_time_to_close(
-                            issue, None
-                        )
-                    num_issues_closed += 1
-                elif issue.state == "open":  # type: ignore
-                    num_issues_open += 1
+            if env_vars.hide_time_to_close is False and issue.state == "closed":  # type: ignore
+                if pull_request:
+                    issue_with_metrics.time_to_close = measure_time_to_merge(
+                        pull_request, ready_for_review_at
+                    )
+                else:
+                    issue_with_metrics.time_to_close = measure_time_to_close(
+                        issue, None
+                    )
+            if issue.state == "closed":  # type: ignore
+                num_issues_closed += 1
+            elif issue.state == "open":  # type: ignore
+                num_issues_open += 1
         issues_with_metrics.append(issue_with_metrics)
 
     return issues_with_metrics, num_issues_open, num_issues_closed

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -297,7 +297,7 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
             "label1": timedelta(days=1),
         }
         num_issues_opened = 2
-        num_issues_closed = 1
+        num_issues_closed = 2
         num_mentor_count = 5
 
         # Call the function
@@ -323,7 +323,7 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
             "| Metric | Count |\n"
             "| --- | ---: |\n"
             "| Number of items that remain open | 2 |\n"
-            "| Number of items closed | 1 |\n"
+            "| Number of items closed | 2 |\n"
             "| Number of most active mentors | 5 |\n"
             "| Total number of items created | 2 |\n\n"
             "| Title | URL | Author |\n"


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->
Fixes #310 

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
This pull request improves the `get_per_issue_metrics` function in `issue_metrics.py` by ...

- Expanding the test coverage in `test_issue_metrics.py` to cover counting logic when env vars are set
- Changing the issue counting logic so it is not gated by the `HIDE_TIME_TO_CLOSE` env var

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
