### PR TITLE
fix: Remove more general part of duplicate actions permissions

### DIFF
--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read-all
+  contents: read
 
 jobs:
   update-major-version-tag:

--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -5,9 +5,6 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
-
 jobs:
   update-major-version-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read-all
+
 jobs:
   update-major-version-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

Remove more general part of duplicate actions permissions. Fixes https://github.com/github/issue-metrics/security/code-scanning/11

Relevant documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Remove `contents: write` at the top level

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
