### PR TITLE
fix: pass through report name, issue title, and search query when report is empty

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -368,7 +368,23 @@ def main():  # pragma: no cover
         issues = get_discussions(token, search_query)
         if len(issues) <= 0:
             print("No discussions found")
-            write_to_markdown(None, None, None, None, None, None, None, None)
+            write_to_markdown(
+                issues_with_metrics=None,
+                average_time_to_first_response=None,
+                average_time_to_close=None,
+                average_time_to_answer=None,
+                average_time_in_labels=None,
+                num_issues_opened=None,
+                num_issues_closed=None,
+                num_mentor_count=None,
+                labels=None,
+                search_query=search_query,
+                hide_label_metrics=False,
+                hide_items_closed_count=False,
+                non_mentioning_links=False,
+                report_title=report_title,
+                output_file=output_file,
+            )
             return
     else:
         issues = search_issues(
@@ -376,7 +392,23 @@ def main():  # pragma: no cover
         )
         if len(issues) <= 0:
             print("No issues found")
-            write_to_markdown(None, None, None, None, None, None, None, None)
+            write_to_markdown(
+                issues_with_metrics=None,
+                average_time_to_first_response=None,
+                average_time_to_close=None,
+                average_time_to_answer=None,
+                average_time_in_labels=None,
+                num_issues_opened=None,
+                num_issues_closed=None,
+                num_mentor_count=None,
+                labels=None,
+                search_query=search_query,
+                hide_label_metrics=False,
+                hide_items_closed_count=False,
+                non_mentioning_links=False,
+                report_title=report_title,
+                output_file=output_file,
+            )
             return
 
     # Get all the metrics

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -7,14 +7,21 @@ also provides functions for sorting the issues by time to first response.
 
 Functions:
     write_to_markdown(
-        issues_with_metrics: List[IssueWithMetrics],
-        average_time_to_first_response: timedelta,
-        average_time_to_close: timedelta,
-        average_time_to_answer: timedelta,
-        num_issues_opened: int,
-        num_issues_closed: int,
-        num_mentor_count: int,
-        file: file object = None
+        issues_with_metrics: Union[List[IssueWithMetrics], None],
+        average_time_to_first_response: Union[dict[str, timedelta], None],
+        average_time_to_close: Union[dict[str, timedelta], None],
+        average_time_to_answer: Union[dict[str, timedelta], None],
+        average_time_in_labels: Union[dict, None],
+        num_issues_opened: Union[int, None],
+        num_issues_closed: Union[int, None],
+        num_mentor_count: Union[int, None],
+        labels=None,
+        search_query=None,
+        hide_label_metrics=False,
+        hide_items_closed_count=False,
+        non_mentioning_links=False,
+        report_title="",
+        output_file="",
     ) -> None:
         Write the issues with metrics to a markdown file.
     get_non_hidden_columns(

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -15,13 +15,13 @@ Functions:
         num_issues_opened: Union[int, None],
         num_issues_closed: Union[int, None],
         num_mentor_count: Union[int, None],
-        labels=None,
-        search_query=None,
-        hide_label_metrics=False,
-        hide_items_closed_count=False,
-        non_mentioning_links=False,
-        report_title="",
-        output_file="",
+        labels: List[str],
+        search_query: str,
+        hide_label_metrics: bool,
+        hide_items_closed_count: bool,
+        non_mentioning_links: bool,
+        report_title: str,
+        output_file: str,
     ) -> None:
         Write the issues with metrics to a markdown file.
     get_non_hidden_columns(

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -8,7 +8,6 @@ Classes:
     TestSearchIssues: A class to test the search_issues function.
     TestGetPerIssueMetrics: A class to test the get_per_issue_metrics function.
     TestGetEnvVars: A class to test the get_env_vars function.
-    TestMain: A class to test the main function.
 
 """
 


### PR DESCRIPTION
# Pull Request
<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Main goal: Ensure that report name, issue title, and search query the pass through properly when the search query results are empty. 
Minor addition: I also improved the readability of the `write_to_markdown` function calls by using named parameters instead of positional parameters.

Example of markdown report before and after this code change:

Before:
```markdown
# 

no issues found for the given search criteria


_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_
```
After:
```markdown
# Issue Metrics

no issues found for the given search criteria


_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_
Search query used to find these items: `repo:github/issue-metrics is:issue created:2024-10-01..2024-10-14`
```

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
