### PR TITLE
fix(GHES): Remove versioning from GraphQL API endpoint URL in discussions.py

### DIFF
--- a/discussions.py
+++ b/discussions.py
@@ -51,7 +51,7 @@ def get_discussions(token: str, search_query: str, ghe: str):
     variables = {"query": search_query}
 
     # Send the GraphQL request
-    api_endpoint = f"{ghe}/api/v3" if ghe else "https://api.github.com"
+    api_endpoint = f"{ghe}/api" if ghe else "https://api.github.com"
     headers = {"Authorization": f"Bearer {token}"}
     response = requests.post(
         f"{api_endpoint}/graphql",


### PR DESCRIPTION
# Pull Request

## Proposed Changes

This pull request modifies the GraphQL API endpoint URL construction in the `discussions.py` file. The change ensures proper handling of GitHub Enterprise Server (GHES) GraphQL API endpoints.

* Removed `/v3` from the API endpoint construction as GraphQL APIs in GHES use `/api/graphql` instead of `/api/v3/graphql`
* This fixes 404 errors when attempting to access GraphQL endpoints on GHES instances

According to the [GitHub Enterprise Server GraphQL documentation](https://docs.github.com/en/enterprise-server@3.15/graphql/guides/introduction-to-graphql#discovering-the-graphql-api), the correct endpoint format is `http(s)://HOSTNAME/api/graphql`. Unlike REST APIs which use versioning (`/api/v3`), GraphQL APIs in GHES do not include version numbers in the URL path.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
