### PR TITLE
fix: use correct created_at issue api attribute

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -160,7 +160,7 @@ def get_per_issue_metrics(
             elif issue.state == "open":  # type: ignore
                 num_issues_open += 1
         if not env_vars.hide_created_at:
-            issue_with_metrics.created_at = issue["createdAt"]
+            issue_with_metrics.created_at = issue["created_at"]
         issues_with_metrics.append(issue_with_metrics)
 
     return issues_with_metrics, num_issues_open, num_issues_closed


### PR DESCRIPTION
Fixes https://github.com/github/issue-metrics/pull/460#issuecomment-2616135404

Looked at the [ReST API for Get an Issue](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue) and the response confirms it should be `created_at` and not `createdAt`

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
