### PR TITLE
fix: Use the `output_file` variable  in `issue_metrics.py`

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -166,6 +166,7 @@ def get_per_issue_metrics(
 
     return issues_with_metrics, num_issues_open, num_issues_closed
 
+
 def evaluate_markdown_file_size(output_file: str) -> None:
     file_name_without_extension = Path(output_file).stem
     max_char_count = 65535
@@ -179,6 +180,7 @@ split into multiple files. ie. {output_file}, {file_name_without_extension}_1.md
 The full file is saved as {file_name_without_extension}_full.md\n\
 See https://github.com/github/issue-metrics/blob/main/docs/dealing-with-large-issue-metrics.md"
         )
+
 
 def main():  # pragma: no cover
     """Run the issue-metrics script.

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -166,6 +166,19 @@ def get_per_issue_metrics(
 
     return issues_with_metrics, num_issues_open, num_issues_closed
 
+def evaluate_markdown_file_size(output_file: str) -> None:
+    file_name_without_extension = Path(output_file).stem
+    max_char_count = 65535
+    if markdown_too_large_for_issue_body(output_file, max_char_count):
+        split_markdown_file(output_file, max_char_count)
+        shutil.move(output_file, f"{file_name_without_extension}_full.md")
+        shutil.move(f"{file_name_without_extension}_0.md", output_file)
+        print(
+            f"Issue metrics markdown file is too large for GitHub issue body and has been \
+split into multiple files. ie. {output_file}, {file_name_without_extension}_1.md, etc. \
+The full file is saved as {file_name_without_extension}_full.md\n\
+See https://github.com/github/issue-metrics/blob/main/docs/dealing-with-large-issue-metrics.md"
+        )
 
 def main():  # pragma: no cover
     """Run the issue-metrics script.
@@ -351,18 +364,7 @@ def main():  # pragma: no cover
         output_file=output_file,
     )
 
-    file_name_without_extension = Path(output_file).stem
-    max_char_count = 65535
-    if markdown_too_large_for_issue_body(output_file, max_char_count):
-        split_markdown_file(output_file, max_char_count)
-        shutil.move(output_file, f"{file_name_without_extension}_full.md")
-        shutil.move(f"{file_name_without_extension}_0.md", output_file)
-        print(
-            f"Issue metrics markdown file is too large for GitHub issue body and has been \
-split into multiple files. ie. {output_file}, {file_name_without_extension}_1.md, etc. \
-The full file is saved as {file_name_without_extension}_full.md\n\
-See https://github.com/github/issue-metrics/blob/main/docs/dealing-with-large-issue-metrics.md"
-        )
+    evaluate_markdown_file_size(output_file)
 
 
 if __name__ == "__main__":

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -350,15 +350,16 @@ def main():  # pragma: no cover
         output_file=output_file,
     )
 
+    file_name_without_extension = output_file.split(".")[0]
     max_char_count = 65535
-    if markdown_too_large_for_issue_body("issue_metrics.md", max_char_count):
-        split_markdown_file("issue_metrics.md", max_char_count)
-        shutil.move("issue_metrics.md", "issue_metrics_full.md")
-        shutil.move("issue_metrics_0.md", "issue_metrics.md")
+    if markdown_too_large_for_issue_body(output_file, max_char_count):
+        split_markdown_file(output_file, max_char_count)
+        shutil.move(output_file, f"{file_name_without_extension}_full.md")
+        shutil.move(f"{file_name_without_extension}_0.md", output_file)
         print(
-            "Issue metrics markdown file is too large for GitHub issue body and has been \
-split into multiple files. ie. issue_metrics.md, issue_metrics_1.md, etc. \
-The full file is saved as issue_metrics_full.md\n\
+            f"Issue metrics markdown file is too large for GitHub issue body and has been \
+split into multiple files. ie. {output_file}, {file_name_without_extension}_1.md, etc. \
+The full file is saved as {file_name_without_extension}_full.md\n\
 See https://github.com/github/issue-metrics/blob/main/docs/dealing-with-large-issue-metrics.md"
         )
 

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -168,6 +168,9 @@ def get_per_issue_metrics(
 
 
 def evaluate_markdown_file_size(output_file: str) -> None:
+    """
+    Evaluate the size of the markdown file and split it, if it is too large.
+    """
     file_name_without_extension = Path(output_file).stem
     max_char_count = 65535
     if markdown_too_large_for_issue_body(output_file, max_char_count):

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -16,6 +16,7 @@ Functions:
 """
 
 import shutil
+from pathlib import Path
 from typing import List, Union
 
 import github3
@@ -350,7 +351,7 @@ def main():  # pragma: no cover
         output_file=output_file,
     )
 
-    file_name_without_extension = output_file.split(".")[0]
+    file_name_without_extension = Path(output_file).stem
     max_char_count = 65535
     if markdown_too_large_for_issue_body(output_file, max_char_count):
         split_markdown_file(output_file, max_char_count)

--- a/markdown_writer.py
+++ b/markdown_writer.py
@@ -225,7 +225,7 @@ def write_to_markdown(
         if search_query:
             file.write(f"Search query used to find these items: `{search_query}`\n")
 
-    print("Wrote issue metrics to issue_metrics.md")
+    print(f"Wrote issue metrics to {output_file_name}")
 
 
 def write_overall_metrics_tables(

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -177,7 +177,6 @@ class TestGetPerIssueMetrics(unittest.TestCase):
             "HIDE_TIME_TO_ANSWER": "false",
             "HIDE_TIME_TO_CLOSE": "false",
             "HIDE_TIME_TO_FIRST_RESPONSE": "false",
-            "OUTPUT_FILE": "test_issue_metrics.md"
         },
     )
     def test_get_per_issue_metrics_without_hide_envs(self):
@@ -483,16 +482,10 @@ class TestDiscussionMetrics(unittest.TestCase):
 class TestEvaluateMarkdownFileSize(unittest.TestCase):
     """Test suite for the evaluate_markdown_file_size function."""
 
-    @patch.dict(
-        os.environ,
-        {
-            "GH_TOKEN": "test_token",
-            "SEARCH_QUERY": "is:issue is:open repo:user/repo",
-            "OUTPUT_FILE": "test_issue_metrics.md"
-        }
-    )
     @patch("issue_metrics.markdown_too_large_for_issue_body")
-    def test_markdown_too_large_for_issue_body_called_with_output_file(self, mock_evaluate):
+    def test_markdown_too_large_for_issue_body_called_with_output_file(
+        self, mock_evaluate
+    ):
         """
         Test that the function uses the output_file.
         """
@@ -501,19 +494,13 @@ class TestEvaluateMarkdownFileSize(unittest.TestCase):
 
         mock_evaluate.assert_called_with("test_issue_metrics.md", 65535)
 
-    @patch.dict(
-        os.environ,
-        {
-            "GH_TOKEN": "test_token",
-            "SEARCH_QUERY": "is:issue is:open repo:user/repo",
-            "OUTPUT_FILE": "test_issue_metrics.md"
-        }
-    )
     @patch("issue_metrics.print")
     @patch("shutil.move")
     @patch("issue_metrics.split_markdown_file")
     @patch("issue_metrics.markdown_too_large_for_issue_body")
-    def test_split_markdown_file_when_file_size_too_large(self, mock_evaluate, mock_split, mock_move, mock_print):
+    def test_split_markdown_file_when_file_size_too_large(
+        self, mock_evaluate, mock_split, mock_move, mock_print
+    ):
         """
         Test that the function is called with the output_file
         environment variable.
@@ -522,16 +509,18 @@ class TestEvaluateMarkdownFileSize(unittest.TestCase):
         evaluate_markdown_file_size("test_issue_metrics.md")
 
         mock_split.assert_called_with("test_issue_metrics.md", 65535)
-        mock_move.assert_has_calls([
-            call("test_issue_metrics.md", "test_issue_metrics_full.md"),
-            call("test_issue_metrics_0.md", "test_issue_metrics.md")
-        ])
+        mock_move.assert_has_calls(
+            [
+                call("test_issue_metrics.md", "test_issue_metrics_full.md"),
+                call("test_issue_metrics_0.md", "test_issue_metrics.md"),
+            ]
+        )
         mock_print.assert_called_with(
             "Issue metrics markdown file is too large for GitHub issue body and has been \
 split into multiple files. ie. test_issue_metrics.md, test_issue_metrics_1.md, etc. \
 The full file is saved as test_issue_metrics_full.md\n\
 See https://github.com/github/issue-metrics/blob/main/docs/dealing-with-large-issue-metrics.md"
-            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Resolves #479 

When the `OUTPUT_FILE` env variable is specified in a calling Action, it is used everywhere except when checking for file size and splitting into multiple files. The default `issue_metrics.md` name was hardcoded.

This PR updates the script to use the provided `output_file` name and uses that naming as the basis for the smaller file names.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
