### PR TITLE
fix: Set default filename, when output file is empty

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -171,15 +171,16 @@ def evaluate_markdown_file_size(output_file: str) -> None:
     """
     Evaluate the size of the markdown file and split it, if it is too large.
     """
-    file_name_without_extension = Path(output_file).stem
+    output_file_name = output_file if output_file else "issue_metrics.md"
+    file_name_without_extension = Path(output_file_name).stem
     max_char_count = 65535
-    if markdown_too_large_for_issue_body(output_file, max_char_count):
-        split_markdown_file(output_file, max_char_count)
-        shutil.move(output_file, f"{file_name_without_extension}_full.md")
-        shutil.move(f"{file_name_without_extension}_0.md", output_file)
+    if markdown_too_large_for_issue_body(output_file_name, max_char_count):
+        split_markdown_file(output_file_name, max_char_count)
+        shutil.move(output_file_name, f"{file_name_without_extension}_full.md")
+        shutil.move(f"{file_name_without_extension}_0.md", output_file_name)
         print(
             f"Issue metrics markdown file is too large for GitHub issue body and has been \
-split into multiple files. ie. {output_file}, {file_name_without_extension}_1.md, etc. \
+split into multiple files. ie. {output_file_name}, {file_name_without_extension}_1.md, etc. \
 The full file is saved as {file_name_without_extension}_full.md\n\
 See https://github.com/github/issue-metrics/blob/main/docs/dealing-with-large-issue-metrics.md"
         )

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -483,6 +483,18 @@ class TestEvaluateMarkdownFileSize(unittest.TestCase):
     """Test suite for the evaluate_markdown_file_size function."""
 
     @patch("issue_metrics.markdown_too_large_for_issue_body")
+    def test_markdown_too_large_for_issue_body_called_with_empty_output_file(
+            self, mock_evaluate
+    ):
+        """
+        Test that the function uses the output_file.
+        """
+        mock_evaluate.return_value = False
+        evaluate_markdown_file_size("")
+
+        mock_evaluate.assert_called_with("issue_metrics.md", 65535)
+
+    @patch("issue_metrics.markdown_too_large_for_issue_body")
     def test_markdown_too_large_for_issue_body_called_with_output_file(
         self, mock_evaluate
     ):

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -484,7 +484,7 @@ class TestEvaluateMarkdownFileSize(unittest.TestCase):
 
     @patch("issue_metrics.markdown_too_large_for_issue_body")
     def test_markdown_too_large_for_issue_body_called_with_empty_output_file(
-            self, mock_evaluate
+        self, mock_evaluate
     ):
         """
         Test that the function uses the output_file.


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

This should fix the regression from #480.

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Set a default filename for the output file in case it is empty.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
