### PR TITLE
fix: handle created_at with diff types

### DIFF
--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -161,7 +161,10 @@ def get_per_issue_metrics(
             elif issue.state == "open":  # type: ignore
                 num_issues_open += 1
         if not env_vars.hide_created_at:
-            issue_with_metrics.created_at = issue["created_at"]
+            if isinstance(issue, github3.search.IssueSearchResult):  # type: ignore
+                issue_with_metrics.created_at = issue.issue.created_at  # type: ignore
+            elif isinstance(issue, dict):  # type: ignore
+                issue_with_metrics.created_at = issue["createdAt"]  # type: ignore
         issues_with_metrics.append(issue_with_metrics)
 
     return issues_with_metrics, num_issues_open, num_issues_closed

--- a/test_config.py
+++ b/test_config.py
@@ -72,6 +72,7 @@ class TestGetEnvVars(unittest.TestCase):
             "GH_TOKEN",
             "GHE",
             "HIDE_AUTHOR",
+            "HIDE_CREATED_AT",
             "HIDE_ITEMS_CLOSED_COUNT",
             "HIDE_LABEL_METRICS",
             "HIDE_TIME_TO_ANSWER",

--- a/test_issue_metrics.py
+++ b/test_issue_metrics.py
@@ -374,9 +374,7 @@ class TestDiscussionMetrics(unittest.TestCase):
         self.issue1 = {
             "title": "Issue 1",
             "url": "github.com/user/repo/issues/1",
-            "user": {
-                "login": "alice",
-            },
+            "user": {"login": "alice"},
             "createdAt": "2023-01-01T00:00:00Z",
             "comments": {
                 "nodes": [
@@ -392,9 +390,7 @@ class TestDiscussionMetrics(unittest.TestCase):
         self.issue2 = {
             "title": "Issue 2",
             "url": "github.com/user/repo/issues/2",
-            "user": {
-                "login": "bob",
-            },
+            "user": {"login": "bob"},
             "createdAt": "2023-01-01T00:00:00Z",
             "comments": {"nodes": [{"createdAt": "2023-01-03T00:00:00Z"}]},
             "answerChosenAt": "2023-01-05T00:00:00Z",
@@ -441,6 +437,7 @@ class TestDiscussionMetrics(unittest.TestCase):
             "GH_TOKEN": "test_token",
             "SEARCH_QUERY": "is:issue is:open repo:user/repo",
             "HIDE_AUTHOR": "true",
+            "HIDE_CREATED_AT": "false",
             "HIDE_LABEL_METRICS": "true",
             "HIDE_TIME_TO_ANSWER": "true",
             "HIDE_TIME_TO_CLOSE": "true",

--- a/test_markdown_writer.py
+++ b/test_markdown_writer.py
@@ -22,6 +22,7 @@ from markdown_writer import write_to_markdown
         "SEARCH_QUERY": "is:open repo:user/repo",
         "GH_TOKEN": "test_token",
         "DRAFT_PR_TRACKING": "True",
+        "HIDE_CREATED_AT": "False",
     },
 )
 class TestWriteToMarkdown(unittest.TestCase):
@@ -44,6 +45,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 title="Issue 1",
                 html_url="https://github.com/user/repo/issues/1",
                 author="alice",
+                created_at=timedelta(days=-5),
                 time_to_first_response=timedelta(days=1),
                 time_to_close=timedelta(days=2),
                 time_to_answer=timedelta(days=3),
@@ -54,6 +56,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 title="Issue 2\r",
                 html_url="https://github.com/user/repo/issues/2",
                 author="bob",
+                created_at=timedelta(days=-5),
                 time_to_first_response=timedelta(days=3),
                 time_to_close=timedelta(days=4),
                 time_to_answer=timedelta(days=5),
@@ -129,12 +132,12 @@ class TestWriteToMarkdown(unittest.TestCase):
             "| Number of most active mentors | 5 |\n"
             "| Total number of items created | 2 |\n\n"
             "| Title | URL | Author | Time to first response | Time to close |"
-            " Time to answer | Time in draft | Time spent in bug |\n"
-            "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+            " Time to answer | Time in draft | Time spent in bug | Created At |\n"
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
             "| Issue 1 | https://github.com/user/repo/issues/1 | [alice](https://github.com/alice) | 1 day, 0:00:00 | "
-            "2 days, 0:00:00 | 3 days, 0:00:00 | 1 day, 0:00:00 | 4 days, 0:00:00 |\n"
+            "2 days, 0:00:00 | 3 days, 0:00:00 | 1 day, 0:00:00 | 4 days, 0:00:00 | -5 days, 0:00:00 |\n"
             "| Issue 2 | https://github.com/user/repo/issues/2 | [bob](https://github.com/bob) | 3 days, 0:00:00 | "
-            "4 days, 0:00:00 | 5 days, 0:00:00 | 1 day, 0:00:00 | 2 days, 0:00:00 |\n\n"
+            "4 days, 0:00:00 | 5 days, 0:00:00 | 1 day, 0:00:00 | 2 days, 0:00:00 | -5 days, 0:00:00 |\n\n"
             "_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_\n"
             "Search query used to find these items: `is:issue is:open label:bug`\n"
         )
@@ -156,6 +159,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 title="Issue 1",
                 html_url="https://github.com/user/repo/issues/1",
                 author="alice",
+                created_at=timedelta(days=-5),
                 time_to_first_response=timedelta(days=1),
                 time_to_close=timedelta(days=2),
                 time_to_answer=timedelta(days=3),
@@ -166,6 +170,7 @@ class TestWriteToMarkdown(unittest.TestCase):
                 title="feat| Issue 2",  # title contains a vertical bar
                 html_url="https://github.com/user/repo/issues/2",
                 author="bob",
+                created_at=timedelta(days=-5),
                 time_to_first_response=timedelta(days=3),
                 time_to_close=timedelta(days=4),
                 time_to_answer=timedelta(days=5),
@@ -238,12 +243,12 @@ class TestWriteToMarkdown(unittest.TestCase):
             "| Number of most active mentors | 5 |\n"
             "| Total number of items created | 2 |\n\n"
             "| Title | URL | Author | Time to first response | Time to close |"
-            " Time to answer | Time in draft | Time spent in bug |\n"
-            "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+            " Time to answer | Time in draft | Time spent in bug | Created At |\n"
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
             "| Issue 1 | https://github.com/user/repo/issues/1 | [alice](https://github.com/alice) | 1 day, 0:00:00 | "
-            "2 days, 0:00:00 | 3 days, 0:00:00 | 1 day, 0:00:00 | 1 day, 0:00:00 |\n"
+            "2 days, 0:00:00 | 3 days, 0:00:00 | 1 day, 0:00:00 | 1 day, 0:00:00 | -5 days, 0:00:00 |\n"
             "| feat&#124; Issue 2 | https://github.com/user/repo/issues/2 | [bob](https://github.com/bob) | 3 days, 0:00:00 | "
-            "4 days, 0:00:00 | 5 days, 0:00:00 | None | 2 days, 0:00:00 |\n\n"
+            "4 days, 0:00:00 | 5 days, 0:00:00 | None | 2 days, 0:00:00 | -5 days, 0:00:00 |\n\n"
             "_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_\n"
         )
         self.assertEqual(content, expected_content)
@@ -287,6 +292,7 @@ class TestWriteToMarkdown(unittest.TestCase):
     {
         "SEARCH_QUERY": "is:open repo:user/repo",
         "GH_TOKEN": "test_token",
+        "HIDE_CREATED_AT": "False",
         "HIDE_TIME_TO_FIRST_RESPONSE": "True",
         "HIDE_TIME_TO_CLOSE": "True",
         "HIDE_TIME_TO_ANSWER": "True",
@@ -309,6 +315,7 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
                 title="Issue 1",
                 html_url="https://github.com/user/repo/issues/1",
                 author="alice",
+                created_at=timedelta(days=-5),
                 time_to_first_response=timedelta(minutes=10),
                 time_to_close=timedelta(days=1),
                 time_to_answer=timedelta(hours=2),
@@ -321,6 +328,7 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
                 title="Issue 2",
                 html_url="https://github.com/user/repo/issues/2",
                 author="bob",
+                created_at=timedelta(days=-5),
                 time_to_first_response=timedelta(minutes=20),
                 time_to_close=timedelta(days=2),
                 time_to_answer=timedelta(hours=4),
@@ -363,6 +371,7 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
         # Check that the function writes the correct markdown file
         with open("issue_metrics.md", "r", encoding="utf-8") as file:
             content = file.read()
+
         expected_content = (
             "# Issue Metrics\n\n"
             "| Metric | Count |\n"
@@ -370,10 +379,10 @@ class TestWriteToMarkdownWithEnv(unittest.TestCase):
             "| Number of items that remain open | 2 |\n"
             "| Number of most active mentors | 5 |\n"
             "| Total number of items created | 2 |\n\n"
-            "| Title | URL | Author |\n"
-            "| --- | --- | --- |\n"
-            "| Issue 1 | https://www.github.com/user/repo/issues/1 | [alice](https://github.com/alice) |\n"
-            "| Issue 2 | https://www.github.com/user/repo/issues/2 | [bob](https://github.com/bob) |\n\n"
+            "| Title | URL | Author | Created At |\n"
+            "| --- | --- | --- | --- |\n"
+            "| Issue 1 | https://www.github.com/user/repo/issues/1 | [alice](https://github.com/alice) | -5 days, 0:00:00 |\n"
+            "| Issue 2 | https://www.github.com/user/repo/issues/2 | [bob](https://github.com/bob) | -5 days, 0:00:00 |\n\n"
             "_This report was generated with the [Issue Metrics Action](https://github.com/github/issue-metrics)_\n"
             "Search query used to find these items: `repo:user/repo is:issue`\n"
         )


### PR DESCRIPTION
Fixes #489

We union dict and github3.search.IssueSearchResult types but their created at attributes are accessed differently.

issue["createdAt"] for dict

issue.issue.created_at for github3.search.IssueSearchResult

- [x] turned off HIDE_CREATED_AT on some tests to ensure we are handling that scenario

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
