### PR TITLE
fix: ensure created_at shows up in json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY requirements.txt *.py /action/workspace/
 
 RUN python3 -m pip install --no-cache-dir -r requirements.txt \
     && apt-get -y update \
-    && apt-get -y install --no-install-recommends git=1:2.39.5-0+deb12u1 \
+    && apt-get -y install --no-install-recommends git=1:2.39.5-0+deb12u2 \
     && rm -rf /var/lib/apt/lists/*
 
 CMD ["/action/workspace/issue_metrics.py"]

--- a/json_writer.py
+++ b/json_writer.py
@@ -182,6 +182,7 @@ def write_to_json(
                 "time_to_answer": str(issue.time_to_answer),
                 "time_in_draft": str(issue.time_in_draft),
                 "label_metrics": formatted_label_metrics,
+                "created_at": str(issue.created_at),
             }
         )
 

--- a/test_json_writer.py
+++ b/test_json_writer.py
@@ -28,6 +28,7 @@ class TestWriteToJson(unittest.TestCase):
                 labels_metrics={
                     "bug": timedelta(days=1, hours=16, minutes=24, seconds=12)
                 },
+                created_at=timedelta(days=-5),
             ),
             IssueWithMetrics(
                 title="Issue 2",
@@ -37,6 +38,7 @@ class TestWriteToJson(unittest.TestCase):
                 time_to_close=timedelta(days=4),
                 time_to_answer=timedelta(days=1),
                 labels_metrics={},
+                created_at=timedelta(days=-5),
             ),
         ]
 
@@ -99,6 +101,7 @@ class TestWriteToJson(unittest.TestCase):
                     "time_to_answer": "None",
                     "time_in_draft": "1 day, 0:00:00",
                     "label_metrics": {"bug": "1 day, 16:24:12"},
+                    "created_at": "-5 days, 0:00:00",
                 },
                 {
                     "title": "Issue 2",
@@ -109,6 +112,7 @@ class TestWriteToJson(unittest.TestCase):
                     "time_to_answer": "1 day, 0:00:00",
                     "time_in_draft": "None",
                     "label_metrics": {},
+                    "created_at": "-5 days, 0:00:00",
                 },
             ],
             "search_query": "is:issue repo:owner/repo",
@@ -143,6 +147,7 @@ class TestWriteToJson(unittest.TestCase):
                 time_to_close=None,
                 time_to_answer=None,
                 labels_metrics={},
+                created_at=None,
             ),
             IssueWithMetrics(
                 title="Issue 2",
@@ -152,6 +157,7 @@ class TestWriteToJson(unittest.TestCase):
                 time_to_close=None,
                 time_to_answer=None,
                 labels_metrics={},
+                created_at=None,
             ),
         ]
 
@@ -198,6 +204,7 @@ class TestWriteToJson(unittest.TestCase):
                     "time_to_answer": "None",
                     "time_in_draft": "None",
                     "label_metrics": {},
+                    "created_at": "None",
                 },
                 {
                     "title": "Issue 2",
@@ -208,6 +215,7 @@ class TestWriteToJson(unittest.TestCase):
                     "time_to_answer": "None",
                     "time_in_draft": "None",
                     "label_metrics": {},
+                    "created_at": "None",
                 },
             ],
             "search_query": "is:issue repo:owner/repo",


### PR DESCRIPTION
Additional fixes for https://github.com/github/issue-metrics/issues/489

- [x] Handle json output of `created_at`
- [x] update git version installed in image

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
