### PR TITLE
fix: harden pip install against supply chain attacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL com.github.actions.name="issue-metrics" \
 WORKDIR /action/workspace
 COPY requirements.txt *.py /action/workspace/
 
-RUN python3 -m pip install --no-cache-dir -r requirements.txt \
+RUN python3 -m pip install --no-cache-dir --no-deps -r requirements.txt \
     && apt-get -y update \
     && apt-get -y install --no-install-recommends git=1:2.47.3-0+deb13u1 \
     && rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,34 @@
-github3.py==4.0.1
+certifi==2026.2.25
+    # via requests
+cffi==2.0.0
+    # via cryptography
+charset-normalizer==3.4.4
+    # via requests
+cryptography==46.0.5
+    # via pyjwt
+github3-py==4.0.1
+    # via -r requirements.txt
+idna==3.11
+    # via requests
 numpy==2.4.2
+    # via -r requirements.txt
+pycparser==3.0
+    # via cffi
+pyjwt==2.11.0
+    # via github3-py
+python-dateutil==2.9.0.post0
+    # via github3-py
 python-dotenv==1.2.1
+    # via -r requirements.txt
 pytz==2025.2
+    # via -r requirements.txt
 requests==2.32.5
+    # via
+    #   -r requirements.txt
+    #   github3-py
+six==1.17.0
+    # via python-dateutil
+uritemplate==4.2.0
+    # via github3-py
+urllib3==2.6.3
+    # via requests


### PR DESCRIPTION
## Summary

Resolves [code scanning alert #94](https://github.com/github-community-projects/issue-metrics/security/code-scanning/94) — `pip install` without hash verification in Dockerfile.

## Changes

### `requirements.txt`
- Expanded via `pip-compile` to pin all transitive dependencies to exact versions (5 top-level → 17 total packages)
- This ensures no implicit dependency resolution happens at install time

### `Dockerfile`
- Added `--no-deps` to `pip install`, preventing pip from resolving any packages beyond the explicit list

## Why this approach

The Opengrep rule recommends two mitigations:
1. `pip install --require-hashes` with hashed requirements
2. `pip install --no-deps` when using a pip-compile workflow

We chose option 2 because `--require-hashes` generates platform-specific hashes that break Dependabot's automated dependency update PRs. The `--no-deps` approach with fully-resolved transitive dependencies provides equivalent security — no unvetted code can be introduced at install time.

This is the same approach used in [stale-repos PR #435](https://github.com/github-community-projects/stale-repos/pull/435).

## Testing

- Verified clean install with `--no-deps` in a fresh venv — all imports succeed
- Full test suite: 137 passed, 4 pre-existing failures (same on `main`)