### PR TITLE
fix: pin uv version and add caching to CI workflows

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          version: "0.10.9"
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.14

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -26,6 +30,9 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          version: "0.10.9"
+          enable-cache: true
       - name: Set up Python
         run: uv python install 3.12
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -26,6 +30,9 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          version: "0.10.9"
+          enable-cache: true
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          version: "0.10.9"
+          enable-cache: true
 
       - name: Update uv.lock
         run: uv lock


### PR DESCRIPTION
## Summary
- Pin uv to version 0.10.9 with caching enabled across all setup-uv action usages
- Add concurrency groups to CI and linter workflows to cancel in-progress runs on new pushes
- Mirrors changes from github-community-projects/evergreen#496

## Test plan
- [x] Verify CI workflows run successfully with pinned uv version
- [x] Verify caching works on subsequent runs
- [x] Verify concurrency cancellation works when pushing multiple times to same branch