### PR TITLE
fix: correct TypeError test to exercise exception handler

### DIFF
--- a/test_time_to_first_review.py
+++ b/test_time_to_first_review.py
@@ -115,10 +115,10 @@ class TestMeasureTimeToFirstReview(unittest.TestCase):
     def test_measure_time_to_first_review_type_error_path(self):
         """Test the except TypeError error handling path."""
         mock_issue = MagicMock()
-        mock_issue.created_at = 12345
+        mock_issue.created_at = "2023-01-01T00:00:00Z"
 
         mock_pr = MagicMock()
-        mock_pr.reviews.return_value = [MagicMock()]
+        mock_pr.reviews.side_effect = TypeError("ghost user")
 
         result = measure_time_to_first_review(mock_issue, mock_pr, None, [])
         self.assertIsNone(result)


### PR DESCRIPTION
# Pull Request

## Proposed Changes

The `test_measure_time_to_first_review_type_error_path` test (added in #683) passes but does not actually exercise the `except TypeError` block in `measure_time_to_first_review`.

The test creates a `MagicMock()` review where `submitted_at` is a `MagicMock` (not a `datetime`). Inside `ignore_comment`, the check `not isinstance(comment_created_at, datetime)` evaluates to `True`, marking it as a pending comment. The review is skipped, `first_review_time` stays `None`, and the function returns `None` at the null check - before ever reaching the code that would raise `TypeError`.

The fix uses `side_effect=TypeError(...)` on the `reviews()` call to properly trigger the exception handling path.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
