### PR TITLE
fix: suppress uv hardlink warning with UV_LINK_MODE=copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD python3 -c "import os,sys; sys.exit(0 if os.path.exists('/action/workspace/issue_metrics.py') else 1)"
 
 ENV PYTHONUNBUFFERED=1
+ENV UV_LINK_MODE=copy
 CMD ["/action/workspace/issue_metrics.py"]
 ENTRYPOINT ["uv", "run", "--no-dev", "--project", "/action/workspace"]


### PR DESCRIPTION
## Proposed Changes

When running as a GitHub Action, the uv cache and target `.venv` directory end up on different filesystems (container overlay vs host mount), causing uv to emit a noisy warning on every run:

```
warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
```

Adding `ENV UV_LINK_MODE=copy` to the Dockerfile tells uv to use copy mode directly, suppressing the warning.

This is the same fix applied in [github-community-projects/pr-conflict-detector#65](https://github.com/github-community-projects/pr-conflict-detector/pull/65).

| | Before | After |
|---|---|---|
| **Hardlink warning** | Printed on every run | Suppressed |

## Testing

- `docker build` - image builds successfully with the new env var

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing